### PR TITLE
Big Refactoring of BMath namespace

### DIFF
--- a/Engine/include/Math/Common.hpp
+++ b/Engine/include/Math/Common.hpp
@@ -5,7 +5,7 @@
 #include <cmath>
 
 // Currently only wrapping std functions
-namespace BMath
+namespace BwatEngine::Math
 {
 
 #pragma region Declarations

--- a/Engine/include/Math/Math.hpp
+++ b/Engine/include/Math/Math.hpp
@@ -5,7 +5,7 @@
 #include "Common.hpp"
 #include "Misc/Misc.hpp"
 #include "Vector/Vectors.hpp"
-#include "Matrix/Matrix4.hpp"
+#include "Matrix/Matrices.hpp"
 #include "Quaternion.hpp"
 
 #endif //BMATH_HPP

--- a/Engine/include/Math/Matrix/Matrix4.hpp
+++ b/Engine/include/Math/Matrix/Matrix4.hpp
@@ -4,157 +4,181 @@
 #include "Math/Meta.hpp"
 #include "Math/Vector/Vector3.hpp"
 
-namespace BMath
-{
-
 #pragma region Declarations
-
-    template<typename T>
-    class Vector3;
-    template<typename T>
-    class Matrix4
+namespace BwatEngine::Math
+{
+    namespace Internal
     {
-    public:
-        union{
-            // Column Major
-            struct {
-                T v0; T v4; T v8;  T v12; // a, b, c, d
-                T v1; T v5; T v9;  T v13; // e, f, g, h
-                T v2; T v6; T v10; T v14; // i, j, k, l
-                T v3; T v7; T v11; T v15; // m, n, o, p
+        template<typename T>
+        class Vector3;
+        template<typename T>
+        class Matrix4
+        {
+        public:
+            union
+            {
+                // Column Major
+                struct
+                {
+                    T v0;
+                    T v4;
+                    T v8;
+                    T v12; // a, b, c, d
+                    T v1;
+                    T v5;
+                    T v9;
+                    T v13; // e, f, g, h
+                    T v2;
+                    T v6;
+                    T v10;
+                    T v14; // i, j, k, l
+                    T v3;
+                    T v7;
+                    T v11;
+                    T v15; // m, n, o, p
+                };
+                T values[4 * 4]{0};
             };
-            T values[4*4]{0};
+
+            // Initialize the diagonal of the matrix
+            ML_FUNC_DECL Matrix4(T x = 0)
+            {
+                values[0 * 4 + 0] = x;
+                values[1 * 4 + 1] = x;
+                values[2 * 4 + 2] = x;
+                values[3 * 4 + 3] = x;
+            }
+
+            // Initialize the diagonal of the matrix
+            ML_FUNC_DECL Matrix4(T x0, T x5, T x10, T x15)
+            {
+                values[0 * 4 + 0] = x0;
+                values[1 * 4 + 1] = x5;
+                values[2 * 4 + 2] = x10;
+                values[3 * 4 + 3] = x15;
+            }
+
+            ML_FUNC_DECL Matrix4(T x0, T x1, T x2, T x3,
+                                 T x4, T x5, T x6, T x7,
+                                 T x8, T x9, T x10, T x11,
+                                 T x12, T x13, T x14, T x15)
+            {
+                v0 = x0;
+                v1 = x1;
+                v2 = x2;
+                v3 = x3;
+                v4 = x4;
+                v5 = x5;
+                v6 = x6;
+                v7 = x7;
+                v8 = x8;
+                v9 = x9;
+                v10 = x10;
+                v11 = x11;
+                v12 = x12;
+                v13 = x13;
+                v14 = x14;
+                v15 = x15;
+            }
+
+            ML_FUNC_DECL Matrix4(const Matrix4 &mat) = default;
+            ML_FUNC_DECL Matrix4(Matrix4 &&mat) noexcept = default;
+            ~Matrix4() = default;
+
+            ML_FUNC_DECL Matrix4 &Transpose();
+            [[nodiscard]] ML_FUNC_DECL Matrix4 GetTranspose() const;
+
+            [[nodiscard]] ML_FUNC_DECL T GetDeterminant();
+
+            ML_FUNC_DECL Matrix4 &Invert();
+            [[nodiscard]] ML_FUNC_DECL Matrix4 GetInverted() const;
+
+            ML_FUNC_DECL Matrix4 &Normalize();
+            [[nodiscard]] ML_FUNC_DECL Matrix4 GetNormalized() const;
+
+            ML_FUNC_DECL Vector4<T> &RotateVector(Vector4<T> &vec) const;
+            [[nodiscard]] ML_FUNC_DECL Vector4<T> GetRotatedVector(const Vector4<T> &vec) const;
+
+            ML_FUNC_DECL Vector4<T> &RotateVector(Internal::Vector3<T> &vec) const;
+            [[nodiscard]] ML_FUNC_DECL Vector4<T> GetRotatedVector(const Internal::Vector3<T> &vec) const;
+
+            static ML_FUNC_DECL Matrix4 CreatePerspective(T left, T right, T bottom, T top, T near, T far);
+            static ML_FUNC_DECL Matrix4 CreatePerspective(T fovy, T aspect, T near, T far);
+            static ML_FUNC_DECL Matrix4 CreateOrtho(T left, T right, T bottom, T top, T near, T far);
+            static ML_FUNC_DECL Matrix4 CreateTranslationMat(Internal::Vector3<T> translation);
+            static ML_FUNC_DECL Matrix4 CreateRotationMat(Internal::Vector3<T> axis, T angle);
+            static ML_FUNC_DECL Matrix4 CreateXRotationMat(T angle);
+            static ML_FUNC_DECL Matrix4 CreateYRotationMat(T angle);
+            static ML_FUNC_DECL Matrix4 CreateZRotationMat(T angle);
+            static ML_FUNC_DECL Matrix4 CreateXYZRotationMat(Internal::Vector3<T> angles);
+            static ML_FUNC_DECL Matrix4 CreateScaleMat(Internal::Vector3<T> scale);
+            static ML_FUNC_DECL Matrix4
+            CreateTRSMat(Internal::Vector3<T> translation, Internal::Vector3<T> rotation, Internal::Vector3<T> scale);
+            static ML_FUNC_DECL Matrix4
+            LookAt(Internal::Vector3<T> origin, Internal::Vector3<T> target, Internal::Vector3<T> upDir);
+
+            [[nodiscard]] ML_FUNC_DECL bool Equals(const Matrix4 &rhs) const;
+            [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
+
+            ML_FUNC_DECL Matrix4 &operator=(const Matrix4 &other);
+
+            [[nodiscard]] ML_FUNC_DECL bool operator==(const Matrix4 &other) const;
+
+            [[nodiscard]] ML_FUNC_DECL bool operator!=(const Matrix4 &other) const;
+
+            [[nodiscard]] ML_FUNC_DECL const T &operator[](int idx) const;
+            [[nodiscard]] ML_FUNC_DECL T &operator[](int idx);
+
+            ML_FUNC_DECL Matrix4 &Add(const Matrix4 &other);
+            [[nodiscard]] ML_FUNC_DECL Matrix4 operator+(const Matrix4 &other) const;
+            ML_FUNC_DECL Matrix4 &operator+=(const Matrix4 &other);
+            ML_FUNC_DECL Matrix4 &operator++();
+
+            ML_FUNC_DECL Matrix4 &Sub(const Matrix4 &other);
+            [[nodiscard]] ML_FUNC_DECL Matrix4 operator-(const Matrix4 &other) const;
+            ML_FUNC_DECL Matrix4 &operator-=(const Matrix4 &other);
+            ML_FUNC_DECL Matrix4 &operator--();
+
+            ML_FUNC_DECL Matrix4 &Mult(const Matrix4 &other);
+            [[nodiscard]] ML_FUNC_DECL Matrix4 operator*(const Matrix4 &other) const;
+            ML_FUNC_DECL Matrix4 &operator*=(const Matrix4 &other);
+
+            ML_FUNC_DECL Vector4<T> &Mult(const Vector4<T> &other);
+            [[nodiscard]] ML_FUNC_DECL Vector4<T> operator*(const Vector4<T> &other) const;
+
+            ML_FUNC_DECL Vector4<T> &Mult(const Internal::Vector3<T> &other);
+            [[nodiscard]] ML_FUNC_DECL Vector4<T> operator*(const Internal::Vector3<T> &other) const;
+
+            [[nodiscard]] ML_FUNC_DECL Matrix4 operator*(const T &scalar) const;
+            ML_FUNC_DECL Matrix4 &operator*=(const T &scalar);
+
+            [[nodiscard]] ML_FUNC_DECL Matrix4 operator/(const T &scalar) const;
+            ML_FUNC_DECL Matrix4 &operator/=(const T &scalar);
         };
+    }
 
-        // Initialize the diagonal of the matrix
-        ML_FUNC_DECL Matrix4(T x = 0)
-        {
-            values[0*4 + 0] = x;
-            values[1*4 + 1] = x;
-            values[2*4 + 2] = x;
-            values[3*4 + 3] = x;
-        }
-
-        // Initialize the diagonal of the matrix
-        ML_FUNC_DECL Matrix4(T x0, T x5, T x10, T x15)
-        {
-            values[0*4 + 0]  = x0;
-            values[1*4 + 1]  = x5;
-            values[2*4 + 2] = x10;
-            values[3*4 + 3] = x15;
-        }
-
-        ML_FUNC_DECL Matrix4(T x0,  T x1,  T x2,  T x3,
-                             T x4,  T x5,  T x6,  T x7,
-                             T x8,  T x9,  T x10, T x11,
-                             T x12, T x13, T x14, T x15)
-        {
-            v0  = x0;
-            v1  = x1;
-            v2  = x2;
-            v3  = x3;
-            v4  = x4;
-            v5  = x5;
-            v6  = x6;
-            v7  = x7;
-            v8  = x8;
-            v9  = x9;
-            v10 = x10;
-            v11 = x11;
-            v12 = x12;
-            v13 = x13;
-            v14 = x14;
-            v15 = x15;
-        }
-
-        ML_FUNC_DECL Matrix4(const Matrix4& mat) = default;
-        ML_FUNC_DECL Matrix4(Matrix4&& mat) noexcept = default;
-        ~Matrix4() = default;
-
-        ML_FUNC_DECL Matrix4& Transpose();
-        [[nodiscard]] ML_FUNC_DECL Matrix4 GetTranspose() const;
-
-        [[nodiscard]] ML_FUNC_DECL T GetDeterminant();
-
-        ML_FUNC_DECL Matrix4& Invert();
-        [[nodiscard]] ML_FUNC_DECL Matrix4 GetInverted() const;
-
-        ML_FUNC_DECL Matrix4& Normalize();
-        [[nodiscard]] ML_FUNC_DECL Matrix4 GetNormalized() const;
-
-        ML_FUNC_DECL Vector4<T>& RotateVector(Vector4<T>& vec) const;
-        [[nodiscard]] ML_FUNC_DECL Vector4<T> GetRotatedVector(const Vector4<T>& vec) const;
-
-        ML_FUNC_DECL Vector4<T>& RotateVector(Vector3<T>& vec) const;
-        [[nodiscard]] ML_FUNC_DECL Vector4<T> GetRotatedVector(const Vector3<T>& vec) const;
-
-        static ML_FUNC_DECL Matrix4 CreatePerspective(T left, T right, T bottom, T top, T near, T far);
-        static ML_FUNC_DECL Matrix4 CreatePerspective(T fovy, T aspect, T near, T far);
-        static ML_FUNC_DECL Matrix4 CreateOrtho(T left, T right, T bottom, T top, T near, T far);
-        static ML_FUNC_DECL Matrix4 CreateTranslationMat(Vector3<T> translation);
-        static ML_FUNC_DECL Matrix4 CreateRotationMat(Vector3<T> axis, T angle);
-        static ML_FUNC_DECL Matrix4 CreateXRotationMat(T angle);
-        static ML_FUNC_DECL Matrix4 CreateYRotationMat(T angle);
-        static ML_FUNC_DECL Matrix4 CreateZRotationMat(T angle);
-        static ML_FUNC_DECL Matrix4 CreateXYZRotationMat(Vector3<T> angles);
-        static ML_FUNC_DECL Matrix4 CreateScaleMat(Vector3<T> scale);
-        static ML_FUNC_DECL Matrix4 CreateTRSMat(Vector3<T> translation, Vector3<T> rotation, Vector3<T> scale);
-        static ML_FUNC_DECL Matrix4 LookAt(Vector3<T> origin, Vector3<T> target, Vector3<T> upDir);
-
-        [[nodiscard]] ML_FUNC_DECL bool Equals(const Matrix4& rhs) const;
-        [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
-
-        ML_FUNC_DECL Matrix4& operator=(const Matrix4& other);
-
-        [[nodiscard]] ML_FUNC_DECL bool operator==(const Matrix4& other) const;
-
-        [[nodiscard]] ML_FUNC_DECL bool operator!=(const Matrix4& other) const;
-
-        [[nodiscard]] ML_FUNC_DECL const T& operator[](int idx) const;
-        [[nodiscard]] ML_FUNC_DECL T& operator[](int idx);
-
-        ML_FUNC_DECL Matrix4& Add(const Matrix4& other);
-        [[nodiscard]] ML_FUNC_DECL Matrix4 operator+(const Matrix4& other) const;
-        ML_FUNC_DECL Matrix4& operator+=(const Matrix4& other);
-        ML_FUNC_DECL Matrix4& operator++();
-
-        ML_FUNC_DECL Matrix4& Sub(const Matrix4& other);
-        [[nodiscard]] ML_FUNC_DECL Matrix4 operator-(const Matrix4& other) const;
-        ML_FUNC_DECL Matrix4& operator-=(const Matrix4& other);
-        ML_FUNC_DECL Matrix4& operator--();
-
-        ML_FUNC_DECL Matrix4& Mult(const Matrix4& other);
-        [[nodiscard]] ML_FUNC_DECL Matrix4 operator*(const Matrix4& other) const;
-        ML_FUNC_DECL Matrix4& operator*=(const Matrix4& other);
-
-        ML_FUNC_DECL Vector4<T>& Mult(const Vector4<T>& other);
-        [[nodiscard]] ML_FUNC_DECL Vector4<T> operator*(const Vector4<T>& other) const;
-
-        ML_FUNC_DECL Vector4<T>& Mult(const Vector3<T>& other);
-        [[nodiscard]] ML_FUNC_DECL Vector4<T> operator*(const Vector3<T>& other) const;
-
-        [[nodiscard]] ML_FUNC_DECL Matrix4 operator*(const T& scalar) const;
-        ML_FUNC_DECL Matrix4& operator*=(const T& scalar);
-
-        [[nodiscard]] ML_FUNC_DECL Matrix4 operator/(const T& scalar) const;
-        ML_FUNC_DECL Matrix4& operator/=(const T& scalar);
-    };
+    typedef Internal::Matrix4<float> Mat4f;
+    typedef Internal::Matrix4<double> Mat4d;
+}
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> operator-(Matrix4<T> mat);
+    [[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Matrix4<T> operator-(BwatEngine::Math::Internal::Matrix4<T> mat);
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> operator*(const T& scalar, Matrix4<T> rhs);
+    [[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Matrix4<T> operator*(const T& scalar, BwatEngine::Math::Internal::Matrix4<T> rhs);
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Lerp(Matrix4<T> begin, Matrix4<T> end, T ratio);
+    [[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Matrix4<T> Lerp(BwatEngine::Math::Internal::Matrix4<T> begin,
+                                                                           BwatEngine::Math::Internal::Matrix4<T> end,
+                                                                           T ratio);
 
 #pragma endregion
 
 #pragma region Definitions
-
+namespace BwatEngine::Math
+{
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::Transpose()
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::Transpose()
     {
         T tmp = values[0*4 + 1];
         values[0*4 + 1] = values[1*4 + 0];
@@ -184,13 +208,13 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Matrix4<T>::GetTranspose() const
+    [[nodiscard]] ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::GetTranspose() const
     {
-        return Matrix4{*this}.Transpose();
+        return Internal::Matrix4<T>{*this}.Transpose();
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL T Matrix4<T>::GetDeterminant()
+    [[nodiscard]] ML_FUNC_DECL T Internal::Matrix4<T>::GetDeterminant()
     {
         T af = values[0*4 + 0]  * values[1*4 + 1];  T ag = values[0*4 + 0]  * values[2*4 + 1];  T ah = values[0*4 + 0]  * values[3*4 + 1]; T be = values[0*4 + 1]  * values[0*4 + 1];
         T bg = values[1*4 + 0]  * values[2*4 + 1];  T bh = values[1*4 + 0]  * values[3*4 + 1];  T ce = values[2*4 + 0]  * values[0*4 + 1];  T cf = values[2*4 + 0]  * values[1*4 + 1];
@@ -205,7 +229,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::Invert()
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::Invert()
     {
         T a00 = values[0*4 + 0];  T a01 = values[0*4 + 1];  T a02 = values[0*4 + 2];  T a03 = values[0*4 + 3];
         T a10 = values[1*4 + 0];  T a11 = values[1*4 + 1];  T a12 = values[1*4 + 2];  T a13 = values[1*4 + 3];
@@ -249,13 +273,13 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Matrix4<T>::GetInverted() const
+    [[nodiscard]] ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::GetInverted() const
     {
-        return Matrix4<T>{*this}.Invert();
+        return Internal::Matrix4<T>{*this}.Invert();
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::Normalize()
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::Normalize()
     {
         T det = GetDeterminant();
         values[0*4 + 0]  /= det;
@@ -279,13 +303,13 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Matrix4<T>::GetNormalized() const
+    [[nodiscard]] ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::GetNormalized() const
     {
-        return Matrix4<T>{*this}.Normalize();
+        return Internal::Matrix4<T>{*this}.Normalize();
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Matrix4<T>::RotateVector(Vector4<T>& vec) const
+    ML_FUNC_DECL Internal::Vector4<T>& Internal::Matrix4<T>::RotateVector(Vector4<T>& vec) const
     {
         vec = Vector4<T>{
             vec.X * values[0*4 + 0] + vec.Y * values[1*4 + 0] + vec.Z * values[2*4 + 0]  + vec.W * values[3*4 + 0],
@@ -297,7 +321,7 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector4<T> Matrix4<T>::GetRotatedVector(const Vector4<T>& vec) const
+    [[nodiscard]] ML_FUNC_DECL Internal::Vector4<T> Internal::Matrix4<T>::GetRotatedVector(const Vector4<T>& vec) const
     {
         return Vector4<T>{
                 vec.X * values[0*4 + 0] + vec.Y * values[1*4 + 0] + vec.Z * values[2*4 + 0]  + vec.W * values[3*4 + 0],
@@ -307,9 +331,9 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Matrix4<T>::RotateVector(Vector3<T>& vec) const
+    ML_FUNC_DECL Internal::Vector4<T>& Internal::Matrix4<T>::RotateVector(Internal::Vector3<T>& vec) const
     {
-        vec = Vector3<T>{
+        vec = Internal::Vector3<T>{
                 vec.X * values[0*4 + 0] + vec.Y * values[1*4 + 0] + vec.Z * values[2*4 + 0]  + vec.W * values[3*4 + 0],
                 vec.X * values[0*4 + 1] + vec.Y * values[1*4 + 1] + vec.Z * values[2*4 + 1]  + vec.W * values[3*4 + 1],
                 vec.X * values[0*4 + 2] + vec.Y * values[1*4 + 2] + vec.Z * values[2*4 + 2] + vec.W * values[3*4 + 2]};
@@ -318,52 +342,52 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector4<T> Matrix4<T>::GetRotatedVector(const Vector3<T>& vec) const
+    [[nodiscard]] ML_FUNC_DECL Internal::Vector4<T> Internal::Matrix4<T>::GetRotatedVector(const Internal::Vector3<T>& vec) const
     {
-        return Vector3<T>{
+        return Internal::Vector3<T>{
                 vec.X * values[0*4 + 0] + vec.Y * values[1*4 + 0] + vec.Z * values[2*4 + 0]  + vec.W * values[3*4 + 0],
                 vec.X * values[0*4 + 1] + vec.Y * values[1*4 + 1] + vec.Z * values[2*4 + 1]  + vec.W * values[3*4 + 1],
                 vec.X * values[0*4 + 2] + vec.Y * values[1*4 + 2] + vec.Z * values[2*4 + 2] + vec.W * values[3*4 + 2]};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreatePerspective(T left, T right, T bottom, T top, T near, T far)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreatePerspective(T left, T right, T bottom, T top, T near, T far)
     {
-        return Matrix4<T>{(near*2)/(right-left), 0                    , (right+left)/(right-left) , 0,
+        return Internal::Matrix4<T>{(near*2)/(right-left), 0                    , (right+left)/(right-left) , 0,
                           0                    , (near*2)/(top-bottom), (top+bottom)/(top-bottom) , 0,
                           0                    , 0                    , -(far+near)/(far-near)    ,-(far * near*2)/(far - near),
                           0                    , 0                    , -1                        , 0};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreatePerspective(T fovy, T aspect, T near, T far)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreatePerspective(T fovy, T aspect, T near, T far)
     {
-        T top = near*tan(BMath::ToRads(fovy)*0.5);
+        T top = near*tan(Math::ToRads(fovy)*0.5);
         T right = top*aspect;
 
         return CreatePerspective(-right, right, -top, top, near, far);
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreateOrtho(T left, T right, T bottom, T top, T near, T far)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreateOrtho(T left, T right, T bottom, T top, T near, T far)
     {
-        return Matrix4<T>{2/(right-left), 0             , 0             , -(right+left)/(right-left),
+        return Internal::Matrix4<T>{2/(right-left), 0             , 0             , -(right+left)/(right-left),
                           0             , 2/(top-bottom), 0             , -(top+bottom)/(top-bottom),
                           0             , 0             ,-2/(far-near)  , -(far+near)/(far-near),
                           0             , 0             , 0             , 1};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreateTranslationMat(Vector3<T> translation)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreateTranslationMat(Internal::Vector3<T> translation)
     {
-        return Matrix4<T>{1, 0, 0, translation.X,
+        return Internal::Matrix4<T>{1, 0, 0, translation.X,
                           0, 1, 0, translation.Y,
                           0, 0, 1, translation.Z,
                           0, 0, 0, 1};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreateRotationMat(Vector3<T> axis, T angle)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreateRotationMat(Internal::Vector3<T> axis, T angle)
     {
         axis.Normalize();
         T sa = Sin(angle);
@@ -374,47 +398,47 @@ namespace BMath
         T y = axis.Y;
         T z = axis.Z;
 
-        return Matrix4<T>{  x*x*t + ca  , y*x*t + z*sa, z*x*t - y*sa, 0.0f,
+        return Internal::Matrix4<T>{  x*x*t + ca  , y*x*t + z*sa, z*x*t - y*sa, 0.0f,
                             x*y*t - z*sa, y*y*t + ca  , z*y*t + x*sa, 0.0f,
                             x*z*t + y*sa, y*z*t - x*sa, z*z*t + ca  , 0.0f,
                             0.0f        , 0.0f        , 0.0f        , 1.0f};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreateXRotationMat(T angle)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreateXRotationMat(T angle)
     {
         T c = Cos(angle);
         T s = Sin(angle);
-        return Matrix4<T>{1, 0, 0, 0,
+        return Internal::Matrix4<T>{1, 0, 0, 0,
                           0, c, s, 0,
                           0,-s, c, 0,
                           0, 0, 0, 1};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreateYRotationMat(T angle)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreateYRotationMat(T angle)
     {
         T c = Cos(angle);
         T s = Sin(angle);
-        return Matrix4<T>{ c, 0,-s, 0,
+        return Internal::Matrix4<T>{ c, 0,-s, 0,
                            0, 1, 0, 0,
                            s, 0, c, 0,
                            0, 0, 0, 1};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreateZRotationMat(T angle)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreateZRotationMat(T angle)
     {
         T c = Cos(angle);
         T s = Sin(angle);
-        return Matrix4<T>{ c, s, 0, 0,
+        return Internal::Matrix4<T>{ c, s, 0, 0,
                            -s, c, 0, 0,
                            0, 0, 1, 0,
                            0, 0, 0, 1};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreateXYZRotationMat(Vector3<T> angles)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreateXYZRotationMat(Internal::Vector3<T> angles)
     {
         float cz = Cos(angles.Z);
         float sz = Sin(angles.Z);
@@ -423,62 +447,62 @@ namespace BMath
         float cx = Cos(angles.X);
         float sx = Sin(angles.X);
 
-        return Matrix4<T>{cz * cy, (cz * sy * sx) - (sz * cx), (cz * sy * cx) + (sz * sx), 0,
+        return Internal::Matrix4<T>{cz * cy, (cz * sy * sx) - (sz * cx), (cz * sy * cx) + (sz * sx), 0,
                           sz * cy, (sz * sy * sx) + (cz * cx), (sz * sy * cx) - (cz * sx), 0,
                           -sy    , cy * sx                   , cy * cx                   , 0,
                           0      , 0                         , 0                          , 1};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreateScaleMat(Vector3<T> scale)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreateScaleMat(Internal::Vector3<T> scale)
     {
-        return Matrix4<T>{scale.X, 0      , 0      , 0,
+        return Internal::Matrix4<T>{scale.X, 0      , 0      , 0,
                           0      , scale.Y, 0      , 0,
                           0      , 0      , scale.Z, 0,
                           0      , 0      , 0      , 1};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::CreateTRSMat(Vector3<T> translation, Vector3<T> rotation, Vector3<T> scale)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::CreateTRSMat(Internal::Vector3<T> translation, Internal::Vector3<T> rotation, Internal::Vector3<T> scale)
     {
         return CreateTranslationMat(translation) * CreateXYZRotationMat(rotation) * CreateScaleMat(scale);
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T> Matrix4<T>::LookAt(Vector3<T> origin, Vector3<T> target, Vector3<T> upDir)
+    ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::LookAt(Internal::Vector3<T> origin, Internal::Vector3<T> target, Internal::Vector3<T> upDir)
     {
-        Vector3<T> forward{origin - target};
+        Internal::Vector3<T> forward{origin - target};
         forward.SafeNormalize();
 
-        Vector3<T> left{upDir.CrossProduct(forward)};
+        Internal::Vector3<T> left{upDir.CrossProduct(forward)};
         left.Normalize();
 
-        Vector3<T> up = forward.CrossProduct(left);
+        Internal::Vector3<T> up = forward.CrossProduct(left);
 
         T m12 = -left.x * origin.X - left.Y * origin.Y - left.Z * origin.Z;
         T m13 = -up.X * origin.X - up.Y * origin.Y - up.Z * origin.Z;
         T m14 = -forward.X * origin.X - forward.Y * origin.Y - forward.Z * origin.Z;
 
-        return Matrix4<T>{left.X   , left.Y   , left.Z   , m12,
+        return Internal::Matrix4<T>{left.X   , left.Y   , left.Z   , m12,
                           up.X     , up.Y     , up.Z     , m13,
                           forward.X, forward.Y, forward.Z, m14,
                           0        , 0        ,0         , 1   };
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL bool Matrix4<T>::Equals(const Matrix4<T>& rhs) const
+    [[nodiscard]] ML_FUNC_DECL bool Internal::Matrix4<T>::Equals(const Internal::Matrix4<T>& rhs) const
     {
         return *this == rhs;
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL bool Matrix4<T>::IsZero() const
+    [[nodiscard]] ML_FUNC_DECL bool Internal::Matrix4<T>::IsZero() const
     {
-        return *this == Matrix4<T>{0};
+        return *this == Internal::Matrix4<T>{0};
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::operator=(const Matrix4<T>& other)
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::operator=(const Internal::Matrix4<T>& other)
     {
         values[0*4 + 0] = other.values[0*4 + 0];
         values[0*4 + 1] = other.values[0*4 + 1];
@@ -501,7 +525,7 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL bool Matrix4<T>::operator==(const Matrix4<T>& other) const
+    [[nodiscard]] ML_FUNC_DECL bool Internal::Matrix4<T>::operator==(const Internal::Matrix4<T>& other) const
     {
         return (values[0*4 + 0] == other.values[0*4 + 0] &&
                 values[0*4 + 1] == other.values[0*4 + 1] &&
@@ -522,34 +546,34 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL bool Matrix4<T>::operator!=(const Matrix4<T>& other) const
+    [[nodiscard]] ML_FUNC_DECL bool Internal::Matrix4<T>::operator!=(const Internal::Matrix4<T>& other) const
     {
         return !(*this == other);
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL const T& Matrix4<T>::operator[](int idx) const
+    [[nodiscard]] ML_FUNC_DECL const T& Internal::Matrix4<T>::operator[](int idx) const
     {
         return values[idx];
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL T& Matrix4<T>::operator[](int idx)
+    [[nodiscard]] ML_FUNC_DECL T& Internal::Matrix4<T>::operator[](int idx)
     {
         return values[idx];
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::Add(const Matrix4<T>& other)
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::Add(const Internal::Matrix4<T>& other)
     {
         *this += other;
         return *this;
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Matrix4<T>::operator+(const Matrix4<T>& other) const
+    [[nodiscard]] ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::operator+(const Internal::Matrix4<T>& other) const
     {
-        return  Matrix4<T> {values[0*4 + 0] + other.values[0*4 + 0],
+        return  Internal::Matrix4<T> {values[0*4 + 0] + other.values[0*4 + 0],
                             values[0*4 + 1] + other.values[0*4 + 1],
                             values[0*4 + 2] + other.values[0*4 + 2],
                             values[0*4 + 3] + other.values[0*4 + 3],
@@ -568,7 +592,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::operator+=(const Matrix4<T>& other)
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::operator+=(const Internal::Matrix4<T>& other)
     {
         values[0*4 + 0] += other.values[0*4 + 0];
         values[0*4 + 1] += other.values[0*4 + 1];
@@ -591,7 +615,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::operator++()
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::operator++()
     {
         values[0*4 + 0]++;
         values[0*4 + 1]++;
@@ -614,16 +638,16 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::Sub(const Matrix4<T>& other)
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::Sub(const Internal::Matrix4<T>& other)
     {
         *this -= other;
         return *this;
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Matrix4<T>::operator-(const Matrix4<T>& other) const
+    [[nodiscard]] ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::operator-(const Internal::Matrix4<T>& other) const
     {
-        return  Matrix4<T> {values[0*4 + 0] - other.values[0*4 + 0],
+        return  Internal::Matrix4<T> {values[0*4 + 0] - other.values[0*4 + 0],
                             values[0*4 + 1] - other.values[0*4 + 1],
                             values[0*4 + 2] - other.values[0*4 + 2],
                             values[0*4 + 3] - other.values[0*4 + 3],
@@ -642,7 +666,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::operator-=(const Matrix4<T>& other)
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::operator-=(const Internal::Matrix4<T>& other)
     {
         values[0*4 + 0] -= other.values[0*4 + 0];
         values[0*4 + 1] -= other.values[0*4 + 1];
@@ -665,7 +689,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::operator--()
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::operator--()
     {
         values[0*4 + 0]--;
         values[0*4 + 1]--;
@@ -688,16 +712,16 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::Mult(const Matrix4& other)
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::Mult(const Internal::Matrix4<T>& other)
     {
         *this *= other;
         return *this;
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Matrix4<T>::operator*(const Matrix4<T>& other) const
+    [[nodiscard]] ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::operator*(const Internal::Matrix4<T>& other) const
     {
-        return Matrix4<T> {values[0*4 + 0] * other.values[0*4 + 0] + values[0*4 + 1] * other.values[1*4 + 0]  + values[0*4 + 2] * other.values[2*4 + 0] + values[0*4 + 3] * other.values[3*4 + 0],
+        return Internal::Matrix4<T> {values[0*4 + 0] * other.values[0*4 + 0] + values[0*4 + 1] * other.values[1*4 + 0]  + values[0*4 + 2] * other.values[2*4 + 0] + values[0*4 + 3] * other.values[3*4 + 0],
                            values[0*4 + 0] * other.values[0*4 + 1] + values[0*4 + 1] * other.values[1*4 + 1]  + values[0*4 + 2] * other.values[2*4 + 1] + values[0*4 + 3] * other.values[3*4 + 1],
                            values[0*4 + 0] * other.values[0*4 + 2] + values[0*4 + 1] * other.values[1*4 + 2]  + values[0*4 + 2] * other.values[2*4 + 2] + values[0*4 + 3] * other.values[3*4 + 2],
                            values[0*4 + 0] * other.values[0*4 + 3] + values[0*4 + 1] * other.values[1*4 + 3]  + values[0*4 + 2] * other.values[2*4 + 3] + values[0*4 + 3] * other.values[3*4 + 3],
@@ -717,7 +741,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::operator*=(const Matrix4<T>& other)
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::operator*=(const Internal::Matrix4<T>& other)
     {
         T tmpV0  = values[0*4 + 0] * other.values[0*4 + 0] + values[0*4 + 1] * other.values[1*4 + 0]  + values[0*4 + 2] * other.values[2*4 + 0] + values[0*4 + 3] * other.values[3*4 + 0];
         T tmpV1  = values[0*4 + 0] * other.values[0*4 + 1] + values[0*4 + 1] * other.values[1*4 + 1]  + values[0*4 + 2] * other.values[2*4 + 1] + values[0*4 + 3] * other.values[3*4 + 1];
@@ -757,9 +781,9 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Matrix4<T>::operator*(const T& scalar) const
+    [[nodiscard]] ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::operator*(const T& scalar) const
     {
-        return  Matrix4<T> {values[0*4 + 0]  * scalar,
+        return  Internal::Matrix4<T> {values[0*4 + 0]  * scalar,
                             values[0*4 + 1]  * scalar,
                             values[0*4 + 2]  * scalar,
                             values[0*4 + 3]  * scalar,
@@ -778,7 +802,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::operator*=(const T& scalar)
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::operator*=(const T& scalar)
     {
         values[0*4 + 0]  *= scalar;
         values[0*4 + 1]  *= scalar;
@@ -801,9 +825,9 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Matrix4<T>::operator/(const T& scalar) const
+    [[nodiscard]] ML_FUNC_DECL Internal::Matrix4<T> Internal::Matrix4<T>::operator/(const T& scalar) const
     {
-        return  Matrix4<T> {values[0*4 + 0]  / scalar,
+        return  Internal::Matrix4<T> {values[0*4 + 0]  / scalar,
                             values[0*4 + 1]  / scalar,
                             values[0*4 + 2]  / scalar,
                             values[0*4 + 3]  / scalar,
@@ -822,7 +846,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4<T>& Matrix4<T>::operator/=(const T& scalar)
+    ML_FUNC_DECL Internal::Matrix4<T>& Internal::Matrix4<T>::operator/=(const T& scalar)
     {
         values[0*4 + 0]  /= scalar;
         values[0*4 + 1]  /= scalar;
@@ -844,41 +868,44 @@ namespace BMath
         return *this;
     }
 
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> operator-(Matrix4<T> mat)
-    {
-        return  Matrix4<T> {-mat.values[0*4 + 0],
-                            -mat.values[0*4 + 1],
-                            -mat.values[0*4 + 2],
-                            -mat.values[0*4 + 3],
-                            -mat.values[1*4 + 0],
-                            -mat.values[1*4 + 1],
-                            -mat.values[1*4 + 2],
-                            -mat.values[1*4 + 3],
-                            -mat.values[2*4 + 0],
-                            -mat.values[2*4 + 1],
-                            -mat.values[2*4 + 2],
-                            -mat.values[2*4 + 3],
-                            -mat.values[3*4 + 0],
-                            -mat.values[3*4 + 1],
-                            -mat.values[3*4 + 2],
-                            -mat.values[3*4 + 3]};
-    }
 
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> operator*(const T& scalar, Matrix4<T> rhs)
-    {
-        return rhs * scalar;
-    }
 
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Matrix4<T> Lerp(Matrix4<T> begin, Matrix4<T> end, T ratio)
-    {
-        ratio = (ratio > 1) ? 1 : (ratio < 0) ?  0 : ratio;
-        return (1 - ratio) * begin + ratio * end;
-    }
-
-#pragma endregion
 
 }
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Matrix4<T> operator-(BwatEngine::Math::Internal::Matrix4<T> mat)
+{
+    return  BwatEngine::Math::Internal::Matrix4<T> {-mat.values[0*4 + 0],
+                                  -mat.values[0*4 + 1],
+                                  -mat.values[0*4 + 2],
+                                  -mat.values[0*4 + 3],
+                                  -mat.values[1*4 + 0],
+                                  -mat.values[1*4 + 1],
+                                  -mat.values[1*4 + 2],
+                                  -mat.values[1*4 + 3],
+                                  -mat.values[2*4 + 0],
+                                  -mat.values[2*4 + 1],
+                                  -mat.values[2*4 + 2],
+                                  -mat.values[2*4 + 3],
+                                  -mat.values[3*4 + 0],
+                                  -mat.values[3*4 + 1],
+                                  -mat.values[3*4 + 2],
+                                  -mat.values[3*4 + 3]};
+}
+
+
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Matrix4<T> operator*(const T& scalar, BwatEngine::Math::Internal::Matrix4<T> rhs)
+{
+    return rhs * scalar;
+}
+
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Matrix4<T> Lerp(BwatEngine::Math::Internal::Matrix4<T> begin, BwatEngine::Math::Internal::Matrix4<T> end, T ratio)
+{
+    ratio = (ratio > 1) ? 1 : (ratio < 0) ?  0 : ratio;
+    return (1 - ratio) * begin + ratio * end;
+}
+#pragma endregion
+
 #endif //MATH_MATRIX4_HPP

--- a/Engine/include/Math/Meta.hpp
+++ b/Engine/include/Math/Meta.hpp
@@ -11,7 +11,7 @@
 // Concatenate constexpr and eventual inline
 #define ML_FUNC_DECL ML_INLINE
 
-namespace BMath
+namespace BwatEngine::Math
 {
     // Magic numbers
     constexpr float PI = 3.1415926535897932;

--- a/Engine/include/Math/Misc/Noise.hpp
+++ b/Engine/include/Math/Misc/Noise.hpp
@@ -4,7 +4,7 @@
 #include "Math/Meta.hpp"
 #include <limits>
 
-namespace BMath {
+namespace BwatEngine::Math {
     // Based on Math for Game Programmers: Noise-Based RNG from GDC 2017
 
 #pragma region Declarations

--- a/Engine/include/Math/Misc/RNG.hpp
+++ b/Engine/include/Math/Misc/RNG.hpp
@@ -3,7 +3,7 @@
 
 #include "Math/Meta.hpp"
 
-namespace BMath
+namespace BwatEngine::Math
 {
 
 #pragma region Declarations

--- a/Engine/include/Math/Quaternion.hpp
+++ b/Engine/include/Math/Quaternion.hpp
@@ -4,281 +4,285 @@
 
 #include "Math/Vector/Vector3.hpp"
 
-namespace BMath
+namespace BwatEngine::Math
 {
 
 #pragma region Declarations
-
-    template<typename T>
-    class Quaternion
+    namespace Internal
     {
-    private:
-        T old_values[4];
-        Matrix4<T> rotation{1};
-
-        bool isDirty()
+        template<typename T>
+        class Quaternion
         {
-            if(*this != Quaternion<T>{old_values[0], old_values[1], old_values[2], old_values[3]})
+        private:
+            T old_values[4];
+            Internal::Matrix4<T> rotation{1};
+
+            bool isDirty()
             {
-                old_values[0] = values[0];
-                old_values[1] = values[1];
-                old_values[2] = values[2];
-                old_values[3] = values[3];
-                return true;
+                if (*this != Quaternion<T>{old_values[0], old_values[1], old_values[2], old_values[3]}) {
+                    old_values[0] = values[0];
+                    old_values[1] = values[1];
+                    old_values[2] = values[2];
+                    old_values[3] = values[3];
+                    return true;
+                }
+                return false;
             }
-            return false;
-        }
-    public:
-        union
-        {
-            struct
+        public:
+            union
             {
-                T X;
-                T Y;
-                T Z;
-                T W;
+                struct
+                {
+                    T X;
+                    T Y;
+                    T Z;
+                    T W;
+                };
+                T values[4];
             };
-            T values[4];
-        };
 
-        ML_FUNC_DECL Quaternion(T x = 0)
+            ML_FUNC_DECL Quaternion(T x = 0)
                 : X(x), Y(x), Z(x), W(x)
-        {}
+            {}
 
-        ML_FUNC_DECL Quaternion(T x, T y, T z, T w)
+            ML_FUNC_DECL Quaternion(T x, T y, T z, T w)
                 : X(x), Y(y), Z(z), W(w)
-        {}
+            {}
 
-        ML_FUNC_DECL Quaternion(Vector3 <T> vec)
+            ML_FUNC_DECL Quaternion(Vector3<T> vec)
                 : X(0), Y(vec.X), Z(vec.Y), W(vec.Z)
-        {}
+            {}
 
-        ML_FUNC_DECL Quaternion(T roll, T pitch, T yaw)
-        {
-            T x0 = Cos(roll / 2);
-            T x1 = Sin(roll / 2);
-            T y0 = Cos(pitch / 2);
-            T y1 = Sin(pitch / 2);
-            T z0 = Cos(yaw / 2);
-            T z1 = Sin(yaw / 2);
+            ML_FUNC_DECL Quaternion(T roll, T pitch, T yaw)
+            {
+                T x0 = Cos(roll / 2);
+                T x1 = Sin(roll / 2);
+                T y0 = Cos(pitch / 2);
+                T y1 = Sin(pitch / 2);
+                T z0 = Cos(yaw / 2);
+                T z1 = Sin(yaw / 2);
 
-            X = x1 * y0 * z0 - x0 * y1 * z1;
-            Y = x0 * y1 * z0 - x1 * y0 * z1;
-            Z = x0 * y0 * z1 - x1 * y1 * z0;
-            W = x0 * y0 * z0 - x1 * y1 * z1;
-        }
+                X = x1 * y0 * z0 - x0 * y1 * z1;
+                Y = x0 * y1 * z0 - x1 * y0 * z1;
+                Z = x0 * y0 * z1 - x1 * y1 * z0;
+                W = x0 * y0 * z0 - x1 * y1 * z1;
+            }
 
-        ML_FUNC_DECL Quaternion(Vector3<T> axis, T angle)
-        {
-            if (Vector3Length(axis) != 0.0f) return Quaternion<T>{0};
+            ML_FUNC_DECL Quaternion(Vector3<T> axis, T angle)
+            {
+                if (Vector3Length(axis) != 0.0f) return Quaternion<T>{0};
 
-            angle *= 0.5;
-            axis.Normalize();
+                angle *= 0.5;
+                axis.Normalize();
 
-            float s = Sin(angle);
-            float c = Cos(angle);
+                float s = Sin(angle);
+                float c = Cos(angle);
 
-            return Quaternion<T>(axis.X * s, axis.Y * s, axis.Z * s, axis.W * c);
-        }
+                return Quaternion<T>(axis.X * s, axis.Y * s, axis.Z * s, axis.W * c);
+            }
 
-        ML_FUNC_DECL Quaternion(const Quaternion &quat) = default;
+            ML_FUNC_DECL Quaternion(const Quaternion &quat) = default;
 
-        ML_FUNC_DECL Quaternion(Quaternion &&quat) noexcept = default;
+            ML_FUNC_DECL Quaternion(Quaternion &&quat) noexcept = default;
 
-        ~Quaternion() = default;
+            ~Quaternion() = default;
 
-        // Compute the amplitude without computing the sqrt
-        // Valid for comparisons, but actually equals to length squared
-        [[nodiscard]] ML_FUNC_DECL float Amplitude() const;
+            // Compute the amplitude without computing the sqrt
+            // Valid for comparisons, but actually equals to length squared
+            [[nodiscard]] ML_FUNC_DECL float Amplitude() const;
 
-        // Return the length of the quaternion
-        // If you only need it for comparison consider using Amplitude()
-        [[nodiscard]] ML_FUNC_DECL float Length() const;
+            // Return the length of the quaternion
+            // If you only need it for comparison consider using Amplitude()
+            [[nodiscard]] ML_FUNC_DECL float Length() const;
 
-        [[nodiscard]] ML_FUNC_DECL float DotProduct(const Quaternion &q) const;
+            [[nodiscard]] ML_FUNC_DECL float DotProduct(const Quaternion &q) const;
 
-        // Scale in place
-        ML_FUNC_DECL Quaternion &Scale(const float &factor);
+            // Scale in place
+            ML_FUNC_DECL Quaternion &Scale(const float &factor);
 
-        // Get a scaled copy of the quaternion
-        [[nodiscard]] ML_FUNC_DECL Quaternion GetScaled(const float &factor) const;
+            // Get a scaled copy of the quaternion
+            [[nodiscard]] ML_FUNC_DECL Quaternion GetScaled(const float &factor) const;
 
-        // Normalize in place
-        ML_FUNC_DECL Quaternion &Normalize();
+            // Normalize in place
+            ML_FUNC_DECL Quaternion &Normalize();
 
-        // Get a normalized copy of the quaternion
-        [[nodiscard]] ML_FUNC_DECL Quaternion GetNormalized() const;
+            // Get a normalized copy of the quaternion
+            [[nodiscard]] ML_FUNC_DECL Quaternion GetNormalized() const;
 
-        // Normalize in place.
-        // Check for length != 0
-        ML_FUNC_DECL Quaternion &SafeNormalize();
+            // Normalize in place.
+            // Check for length != 0
+            ML_FUNC_DECL Quaternion &SafeNormalize();
 
-        // Get a normalized copy of the quaternion
-        // If quaternion length == 0, return quaternion{0}
-        [[nodiscard]] ML_FUNC_DECL Quaternion GetSafeNormalized() const;
+            // Get a normalized copy of the quaternion
+            // If quaternion length == 0, return quaternion{0}
+            [[nodiscard]] ML_FUNC_DECL Quaternion GetSafeNormalized() const;
 
-        // Conjugate in place
-        ML_FUNC_DECL Quaternion &Conjugate();
+            // Conjugate in place
+            ML_FUNC_DECL Quaternion &Conjugate();
 
-        // Get a conjugate copy of the quaternion
-        [[nodiscard]] ML_FUNC_DECL Quaternion GetConjugate() const;
+            // Get a conjugate copy of the quaternion
+            [[nodiscard]] ML_FUNC_DECL Quaternion GetConjugate() const;
 
-        ML_FUNC_DECL Quaternion &Invert();
+            ML_FUNC_DECL Quaternion &Invert();
 
-        [[nodiscard]] ML_FUNC_DECL Quaternion GetInverted() const;
+            [[nodiscard]] ML_FUNC_DECL Quaternion GetInverted() const;
 
-        [[nodiscard]] ML_FUNC_DECL Matrix4<T> GetRotationMatrix();
+            [[nodiscard]] ML_FUNC_DECL Internal::Matrix4<T> GetRotationMatrix();
 
-        [[nodiscard]] ML_FUNC_DECL Vector3<T> GetEulerAngles();
+            [[nodiscard]] ML_FUNC_DECL Vector3<T> GetEulerAngles();
 
-        [[nodiscard]] ML_FUNC_DECL Vector3<T> Rotate(Vector3<T> vec);
+            [[nodiscard]] ML_FUNC_DECL Vector3<T> Rotate(Vector3<T> vec);
 
-        [[nodiscard]] ML_FUNC_DECL bool Equals(const Quaternion &rhs) const;
+            [[nodiscard]] ML_FUNC_DECL bool Equals(const Quaternion &rhs) const;
 
-        [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
+            [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
 
-        ML_FUNC_DECL Quaternion &operator=(const Quaternion &other);
+            ML_FUNC_DECL Quaternion &operator=(const Quaternion &other);
 
-        [[nodiscard]] ML_FUNC_DECL bool operator==(const Quaternion &rhs) const;
+            [[nodiscard]] ML_FUNC_DECL bool operator==(const Quaternion &rhs) const;
 
-        [[nodiscard]] ML_FUNC_DECL bool operator!=(const Quaternion &rhs) const;
+            [[nodiscard]] ML_FUNC_DECL bool operator!=(const Quaternion &rhs) const;
 
-        [[nodiscard]] ML_FUNC_DECL const T &operator[](int idx) const;
+            [[nodiscard]] ML_FUNC_DECL const T &operator[](int idx) const;
 
-        [[nodiscard]] ML_FUNC_DECL T &operator[](int idx);
+            [[nodiscard]] ML_FUNC_DECL T &operator[](int idx);
 
-        ML_FUNC_DECL Quaternion &Add(const Quaternion &quat);
+            ML_FUNC_DECL Quaternion &Add(const Quaternion &quat);
 
-        [[nodiscard]] ML_FUNC_DECL Quaternion operator+(const Quaternion &rhs) const;
+            [[nodiscard]] ML_FUNC_DECL Quaternion operator+(const Quaternion &rhs) const;
 
-        ML_FUNC_DECL Quaternion &operator+=(const Quaternion &quat);
+            ML_FUNC_DECL Quaternion &operator+=(const Quaternion &quat);
 
-        ML_FUNC_DECL Quaternion &operator++();
+            ML_FUNC_DECL Quaternion &operator++();
 
-        ML_FUNC_DECL Quaternion &Sub(const Quaternion &quat);
+            ML_FUNC_DECL Quaternion &Sub(const Quaternion &quat);
 
-        [[nodiscard]] ML_FUNC_DECL Quaternion operator-(const Quaternion &rhs) const;
+            [[nodiscard]] ML_FUNC_DECL Quaternion operator-(const Quaternion &rhs) const;
 
-        ML_FUNC_DECL Quaternion &operator-=(const Quaternion &quat);
+            ML_FUNC_DECL Quaternion &operator-=(const Quaternion &quat);
 
-        ML_FUNC_DECL Quaternion &operator--();
+            ML_FUNC_DECL Quaternion &operator--();
 
-        ML_FUNC_DECL Quaternion &Mul(const Quaternion &quat);
+            ML_FUNC_DECL Quaternion &Mul(const Quaternion &quat);
 
-        [[nodiscard]] ML_FUNC_DECL Quaternion operator*(const Quaternion &quat) const;
+            [[nodiscard]] ML_FUNC_DECL Quaternion operator*(const Quaternion &quat) const;
 
-        ML_FUNC_DECL Quaternion &operator*=(const Quaternion &quat);
+            ML_FUNC_DECL Quaternion &operator*=(const Quaternion &quat);
 
-        [[nodiscard]] ML_FUNC_DECL Quaternion operator*(const float &scalar) const;
+            [[nodiscard]] ML_FUNC_DECL Quaternion operator*(const float &scalar) const;
 
-        ML_FUNC_DECL Quaternion &operator*=(const float &scalar);
+            ML_FUNC_DECL Quaternion &operator*=(const float &scalar);
 
-        [[nodiscard]] ML_FUNC_DECL Quaternion operator/(const float &scalar) const;
+            [[nodiscard]] ML_FUNC_DECL Quaternion operator/(const float &scalar) const;
 
-        ML_FUNC_DECL Quaternion &operator/=(const float &scalar);
+            ML_FUNC_DECL Quaternion &operator/=(const float &scalar);
 
-    };
+        };
+    }
+    typedef Internal::Quaternion<float> Quatf;
+    typedef Internal::Quaternion<double> Quatd;
+}
+    template<typename T>
+    [[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Quaternion<T> operator-(BwatEngine::Math::Internal::Quaternion<T> quat);
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Quaternion<T> operator-(Quaternion<T> quat);
+    [[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Quaternion<T> operator*(const float &scalar, BwatEngine::Math::Internal::Quaternion<T> rhs);
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Quaternion<T> operator*(const float &scalar, Quaternion<T> rhs);
+    [[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Quaternion<T> Lerp(BwatEngine::Math::Internal::Quaternion<T> begin, BwatEngine::Math::Internal::Quaternion<T> end, float ratio);
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Quaternion<T> Lerp(Quaternion<T> begin, Quaternion<T> end, float ratio);
+    [[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Quaternion<T> NLerp(BwatEngine::Math::Internal::Quaternion<T> begin, BwatEngine::Math::Internal::Quaternion<T> end, float ratio);
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Quaternion<T> NLerp(Quaternion<T> begin, Quaternion<T> end, float ratio);
-
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Quaternion<T> SLerp(Quaternion<T> begin, Quaternion<T> end, float ratio);
+    [[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Quaternion<T> SLerp(BwatEngine::Math::Internal::Quaternion<T> begin, BwatEngine::Math::Internal::Quaternion<T> end, float ratio);
 
 #pragma endregion
 
 #pragma region Definitions
-
+namespace BwatEngine::Math
+{
     template<typename T>
-    ML_FUNC_DECL float Quaternion<T>::Amplitude() const
+    ML_FUNC_DECL float Internal::Quaternion<T>::Amplitude() const
     {
         return DotProduct(*this);
     }
 
     template<typename T>
-    ML_FUNC_DECL float Quaternion<T>::Length() const
+    ML_FUNC_DECL float Internal::Quaternion<T>::Length() const
     {
         return std::sqrt(Amplitude());
     }
 
     template<typename T>
-    ML_FUNC_DECL float Quaternion<T>::DotProduct(const Quaternion &q) const
+    ML_FUNC_DECL float Internal::Quaternion<T>::DotProduct(const Internal::Quaternion<T> &q) const
     {
         return (X * X + Y * Y + Z * Z + W * W);
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::Add(const Quaternion &quat)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::Add(const Internal::Quaternion<T> &quat)
     {
         *this += quat;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::Sub(const Quaternion &quat)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::Sub(const Internal::Quaternion<T> &quat)
     {
         *this -= quat;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::Mul(const Quaternion &quat)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::Mul(const Internal::Quaternion<T> &quat)
     {
         *this *= quat;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::Scale(const float &factor)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::Scale(const float &factor)
     {
         *this *= factor;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> Quaternion<T>::GetScaled(const float &factor) const
+    ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::GetScaled(const float &factor) const
     {
         return *this * factor;
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::Normalize()
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::Normalize()
     {
         *this /= Length();
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> Quaternion<T>::GetNormalized() const
+    ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::GetNormalized() const
     {
-        return Quaternion{*this} / Length();
+        return Internal::Quaternion{*this} / Length();
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::SafeNormalize()
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::SafeNormalize()
     {
         if (Amplitude() == 0) return *this;
         return Normalize();
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> Quaternion<T>::GetSafeNormalized() const
+    ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::GetSafeNormalized() const
     {
-        if (Amplitude() == 0) return Quaternion<T>{0};
+        if (Amplitude() == 0) return Internal::Quaternion<T>{0};
         return GetNormalized();
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::Conjugate()
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::Conjugate()
     {
         X *= -1;
         Y *= -1;
@@ -288,27 +292,27 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> Quaternion<T>::GetConjugate() const
+    ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::GetConjugate() const
     {
-        return Quaternion<T>{X, Y, Z, W};
+        return Internal::Quaternion<T>{X, Y, Z, W};
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::Invert()
-    {
-        *this = Conjugate() / Amplitude();
-        return *this;
-    }
-
-    template<typename T>
-    ML_FUNC_DECL Quaternion<T> Quaternion<T>::GetInverted() const
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::Invert()
     {
         *this = Conjugate() / Amplitude();
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Matrix4 <T> Quaternion<T>::GetRotationMatrix()
+    ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::GetInverted() const
+    {
+        *this = Conjugate() / Amplitude();
+        return *this;
+    }
+
+    template<typename T>
+    ML_FUNC_DECL Internal::Matrix4 <T> Internal::Quaternion<T>::GetRotationMatrix()
     {
         if (isDirty())
         {
@@ -317,7 +321,7 @@ namespace BMath
             float xy = 2 * (X * Y), xz = 2 * (X * Z), yz = 2 * (Y * Z);
             float xw = 2 * (X * W), yw = 2 * (Y * W), zw = 2 * (Z * W);
 
-            rotation = Matrix4<T>{1 - y2 - z2, xy + zw    , xz - yw    , 0,
+            rotation = Internal::Matrix4<T>{1 - y2 - z2, xy + zw    , xz - yw    , 0,
                               xy - zw    , 1 - x2 - z2, yz + xw    , 0,
                               xz + yw    , yz - xw    , 1 - x2 - y2, 0,
                               0          , 0          , 0          , 1};
@@ -330,7 +334,7 @@ namespace BMath
 
 
     template <typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector3<T> Quaternion<T>::GetEulerAngles()
+    [[nodiscard]] ML_FUNC_DECL Internal::Vector3<T> Internal::Quaternion<T>::GetEulerAngles()
     {
         // roll (x-axis rotation)
         float x0 = 2.0*(W*X + Y*Z);
@@ -348,7 +352,7 @@ namespace BMath
         return Vector3<T>{ToDegs(Atan2(x0, x1)), ToDegs(Asin(y0)), ToDegs(Atan2(z0, z1))};
     }
     template <typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector3<T> Quaternion<T>::Rotate(Vector3<T> v)
+    [[nodiscard]] ML_FUNC_DECL Internal::Vector3<T> Internal::Quaternion<T>::Rotate(Vector3<T> v)
     {
         return Vector3<T>{v.X*(X*X + W*W - Y*Y - Z*Z) + v.y*(2*X*Y - 2*W*Z) + v.z*(2*X*Z + 2*W*Y),
                           v.X*(2*W*Z + 2*X*Y) + v.y*(W*W - X*X + Y*Y - Z*Z) + v.z*(-2*W*X + 2*Y*Z),
@@ -356,19 +360,19 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Quaternion<T>::Equals(const Quaternion &rhs) const
+    ML_FUNC_DECL bool Internal::Quaternion<T>::Equals(const Internal::Quaternion<T> &rhs) const
     {
         return *this == rhs;
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Quaternion<T>::IsZero() const
+    ML_FUNC_DECL bool Internal::Quaternion<T>::IsZero() const
     {
-        return *this == Quaternion<T>{0};
+        return *this == Internal::Quaternion<T>{0};
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::operator=(const Quaternion &other)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::operator=(const Internal::Quaternion<T> &other)
     {
         X = other.X;
         Y = other.Y;
@@ -378,7 +382,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Quaternion<T>::operator==(const Quaternion &rhs) const
+    ML_FUNC_DECL bool Internal::Quaternion<T>::operator==(const Internal::Quaternion<T> &rhs) const
     {
         return (X == rhs.X &&
                 Y == rhs.Y &&
@@ -387,34 +391,34 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Quaternion<T>::operator!=(const Quaternion &rhs) const
+    ML_FUNC_DECL bool Internal::Quaternion<T>::operator!=(const Internal::Quaternion<T> &rhs) const
     {
         return !(*this == rhs);
     }
 
     template<typename T>
-    ML_FUNC_DECL const T &Quaternion<T>::operator[](int idx) const
+    ML_FUNC_DECL const T &Internal::Quaternion<T>::operator[](int idx) const
     {
         return values[idx];
     }
 
     template<typename T>
-    ML_FUNC_DECL T &Quaternion<T>::operator[](int idx)
+    ML_FUNC_DECL T &Internal::Quaternion<T>::operator[](int idx)
     {
         return values[idx];
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> Quaternion<T>::operator+(const Quaternion &rhs) const
+    ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::operator+(const Internal::Quaternion<T> &rhs) const
     {
-        return Quaternion<T>{X + rhs.X,
+        return Internal::Quaternion<T>{X + rhs.X,
                              Y + rhs.Y,
                              Z + rhs.Z,
                              W + rhs.W};
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::operator+=(const Quaternion &quat)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::operator+=(const Internal::Quaternion<T> &quat)
     {
         X += quat.X;
         Y += quat.Y;
@@ -424,7 +428,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::operator++()
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::operator++()
     {
         X++;
         Y++;
@@ -434,16 +438,16 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> Quaternion<T>::operator-(const Quaternion &rhs) const
+    ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::operator-(const Internal::Quaternion<T> &rhs) const
     {
-        return Quaternion<T>{X - rhs.X,
+        return Internal::Quaternion<T>{X - rhs.X,
                              Y - rhs.Y,
                              Z - rhs.Z,
                              W - rhs.W};
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::operator-=(const Quaternion &quat)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::operator-=(const Internal::Quaternion<T> &quat)
     {
         X -= quat.X;
         Y -= quat.Y;
@@ -453,7 +457,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::operator--()
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::operator--()
     {
         X--;
         Y--;
@@ -463,43 +467,43 @@ namespace BMath
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Quaternion<T> operator-(Quaternion<T> quat)
+    [[nodiscard]] ML_FUNC_DECL Internal::Quaternion<T> operator-(Internal::Quaternion<T> quat)
     {
-        return Quaternion<T>{-quat.X, -quat.Y, -quat.Z, -quat.W};
+        return Internal::Quaternion<T>{-quat.X, -quat.Y, -quat.Z, -quat.W};
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Quaternion<T> Quaternion<T>::operator*(const Quaternion &quat) const
+    [[nodiscard]] ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::operator*(const Internal::Quaternion<T> &quat) const
     {
-        return Quaternion<T>{W * quat.W - X * quat.X - Y * quat.Y - Z * quat.Z,
+        return Internal::Quaternion<T>{W * quat.W - X * quat.X - Y * quat.Y - Z * quat.Z,
                              W * quat.X + X * quat.W + Y * quat.Z - Z * quat.Y,
                              W * quat.Y + Y * quat.W + Z * quat.X - X * quat.Z,
                              W * quat.Z + Z * quat.W + X * quat.Y - Y * quat.X};
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::operator*=(const Quaternion &quat)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::operator*=(const Internal::Quaternion<T> &quat)
     {
         *this = *this * quat;
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> Quaternion<T>::operator*(const float &scalar) const
+    ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::operator*(const float &scalar) const
     {
-        return Quaternion<T>{X * scalar,
+        return Internal::Quaternion<T>{X * scalar,
                              Y * scalar,
                              Z * scalar,
                              W * scalar};
     }
 
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Quaternion<T> operator*(const float &scalar, Quaternion<T> rhs)
+    [[nodiscard]] ML_FUNC_DECL Internal::Quaternion<T> operator*(const float &scalar, Internal::Quaternion<T> rhs)
     {
         return rhs * scalar;
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::operator*=(const float &scalar)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::operator*=(const float &scalar)
     {
         X *= scalar;
         Y *= scalar;
@@ -509,16 +513,16 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> Quaternion<T>::operator/(const float &scalar) const
+    ML_FUNC_DECL Internal::Quaternion<T> Internal::Quaternion<T>::operator/(const float &scalar) const
     {
-        return Quaternion<T>{X / scalar,
+        return Internal::Quaternion<T>{X / scalar,
                              Y / scalar,
                              Z / scalar,
                              W / scalar};
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> &Quaternion<T>::operator/=(const float &scalar)
+    ML_FUNC_DECL Internal::Quaternion<T> &Internal::Quaternion<T>::operator/=(const float &scalar)
     {
         X /= scalar;
         Y /= scalar;
@@ -528,21 +532,21 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> Lerp(Quaternion<T> begin, Quaternion<T> end, float ratio)
+    ML_FUNC_DECL Internal::Quaternion<T> Lerp(Internal::Quaternion<T> begin, Internal::Quaternion<T> end, float ratio)
     {
         ratio = (ratio > 1) ? 1 : (ratio < 0) ? 0 : ratio;
         return (1 - ratio) * begin + ratio * end;
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> NLerp(Quaternion<T> begin, Quaternion<T> end, float ratio)
+    ML_FUNC_DECL Internal::Quaternion<T> NLerp(Internal::Quaternion<T> begin, Internal::Quaternion<T> end, float ratio)
     {
         ratio = (ratio > 1) ? 1 : (ratio < 0) ? 0 : ratio;
-        return Quaternion<T>{(1 - ratio) * begin + ratio * end}.Normalize();
+        return Internal::Quaternion<T>{(1 - ratio) * begin + ratio * end}.Normalize();
     }
 
     template<typename T>
-    ML_FUNC_DECL Quaternion<T> SLerp(Quaternion<T> begin, Quaternion<T> end, float ratio)
+    ML_FUNC_DECL Internal::Quaternion<T> SLerp(Internal::Quaternion<T> begin, Internal::Quaternion<T> end, float ratio)
     {
         float cosHalfTheta = begin.X * end.X + begin.Y * end.Y + begin.Z * end.Z + begin.W * end.W;
 
@@ -553,7 +557,7 @@ namespace BMath
         float sinHalfTheta = Sqrt(1.0 - cosHalfTheta * cosHalfTheta);
 
         if (Abs(sinHalfTheta) < 0.001)
-            return Quaternion<T>{
+            return Internal::Quaternion<T>{
                     begin.X * 0.5 + end.X * 0.5,
                     begin.Y * 0.5 + end.Y * 0.5,
                     begin.Z * 0.5 + end.Z * 0.5,
@@ -561,7 +565,7 @@ namespace BMath
         float ratioA = Sin((1 - ratio) * halfTheta) / sinHalfTheta;
         float ratioB = Sin(ratio * halfTheta) / sinHalfTheta;
 
-        return Quaternion<T>{(begin.X * ratioA + end.X * ratioB),
+        return Internal::Quaternion<T>{(begin.X * ratioA + end.X * ratioB),
                              (begin.Y * ratioA + end.Y * ratioB),
                              (begin.Z * ratioA + end.Z * ratioB),
                              (begin.W * ratioA + end.W * ratioB)};

--- a/Engine/include/Math/Vector/Vector2.hpp
+++ b/Engine/include/Math/Vector/Vector2.hpp
@@ -7,203 +7,216 @@
 
 #include "Math/Meta.hpp"
 
-namespace BMath
+namespace BwatEngine::Math
 {
 
 #pragma region Declarations
-
-    template<typename T>
-    class Vector2
+    namespace Internal
     {
-    public:
-        union
+        template<typename T>
+        class Vector2
         {
-            struct
+        public:
+            union
             {
-                T X;
-                T Y;
+                struct
+                {
+                    T X;
+                    T Y;
+                };
+                T values[2];
             };
-            T values[2];
+
+            ML_FUNC_DECL Vector2(T x = 0)
+                : X(x), Y(x)
+            {}
+
+            ML_FUNC_DECL Vector2(T x, T y)
+                : X(x), Y(y)
+            {}
+
+            ML_FUNC_DECL Vector2(const Vector2 &vec) = default;
+            ML_FUNC_DECL Vector2(Vector2 &&vec) noexcept = default;
+
+            template<typename U>
+            ML_FUNC_DECL Vector2(const Vector2<U> &vec)
+                : X(static_cast<T>(vec.X)), Y(static_cast<T>(vec.Y))
+            {}
+
+            ~Vector2() = default;
+
+            [[nodiscard]] ML_FUNC_DECL float DotProduct(const Vector2 &v) const;
+
+            // Compute the amplitude without computing the sqrt
+            // Valid for comparisons, but actually equals to length squared
+            [[nodiscard]] ML_FUNC_DECL float Amplitude() const;
+
+            // Return the length of the vector
+            // If you only need it for comparison consider using Amplitude()
+            [[nodiscard]] ML_FUNC_DECL float Length() const;
+
+            // Scale in place
+            ML_FUNC_DECL Vector2 &Scale(const float &factor);
+
+            // Get a scaled copy of the vector
+            [[nodiscard]] ML_FUNC_DECL Vector2 GetScaled(const float &factor) const;
+
+            // Normalize in place
+            ML_FUNC_DECL Vector2 &Normalize();
+
+            // Get a normalized copy of the vector
+            [[nodiscard]] ML_FUNC_DECL Vector2 GetNormalized() const;
+
+            // Normalize in place.
+            // Check for length != 0
+            ML_FUNC_DECL Vector2 &SafeNormalize();
+
+            // Get a normalized copy of the vector
+            // If vector length == 0, return Vector{0}
+            [[nodiscard]] ML_FUNC_DECL Vector2 GetSafeNormalized() const;
+
+            [[nodiscard]] ML_FUNC_DECL bool Equals(const Vector2 &rhs) const;
+            [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
+
+            ML_FUNC_DECL Vector2 &operator=(const Vector2 &other);
+
+            [[nodiscard]] ML_FUNC_DECL bool operator==(const Vector2 &rhs) const;
+
+            [[nodiscard]] ML_FUNC_DECL bool operator!=(const Vector2 &rhs) const;
+
+            [[nodiscard]] ML_FUNC_DECL const T &operator[](int idx) const;
+            [[nodiscard]] ML_FUNC_DECL T &operator[](int idx);
+
+            ML_FUNC_DECL Vector2 &Add(const Vector2 &vec);
+            [[nodiscard]] ML_FUNC_DECL Vector2 operator+(const Vector2 &rhs) const;
+            ML_FUNC_DECL Vector2 &operator+=(const Vector2 &vec);
+            ML_FUNC_DECL Vector2 &operator++();
+
+            ML_FUNC_DECL Vector2 &Sub(const Vector2 &vec);
+            [[nodiscard]] ML_FUNC_DECL Vector2 operator-(const Vector2 &rhs) const;
+            ML_FUNC_DECL Vector2 &operator-=(const Vector2 &vec);
+            ML_FUNC_DECL Vector2 &operator--();
+
+            [[nodiscard]] ML_FUNC_DECL Vector2 operator*(const float &scalar) const;
+            ML_FUNC_DECL Vector2 &operator*=(const float &scalar);
+
+            [[nodiscard]] ML_FUNC_DECL Vector2 operator/(const float &scalar) const;
+            ML_FUNC_DECL Vector2 &operator/=(const float &scalar);
+
         };
+    }
 
-        ML_FUNC_DECL Vector2(T x = 0)
-            : X(x), Y(x)
-        {}
+    typedef Internal::Vector2<float> Vec2f;
 
-        ML_FUNC_DECL Vector2(T x, T y)
-            : X(x), Y(y)
-        {}
+    typedef Internal::Vector2<double> Vec2d;
 
-        ML_FUNC_DECL Vector2(const Vector2& vec) = default;
-        ML_FUNC_DECL Vector2(Vector2&& vec) noexcept = default;
+    typedef Internal::Vector2<signed int> Vec2i;
 
-        template<typename U>
-        ML_FUNC_DECL Vector2(const Vector2<U>& vec)
-            : X(static_cast<T>(vec.X)), Y(static_cast<T>(vec.Y))
-        {}
+    typedef Internal::Vector2<unsigned int> Vec2u;
+}
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector2<T> operator-(BwatEngine::Math::Internal::Vector2<T> vec);
 
-        ~Vector2() = default;
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector2<T>operator*(const float &scalar,
+                                                                           BwatEngine::Math::Internal::Vector2<T> rhs);
 
-        [[nodiscard]] ML_FUNC_DECL float DotProduct(const Vector2& v) const;
-
-        // Compute the amplitude without computing the sqrt
-        // Valid for comparisons, but actually equals to length squared
-        [[nodiscard]] ML_FUNC_DECL float Amplitude() const;
-
-        // Return the length of the vector
-        // If you only need it for comparison consider using Amplitude()
-        [[nodiscard]] ML_FUNC_DECL float Length() const;
-
-        // Scale in place
-        ML_FUNC_DECL Vector2& Scale(const float& factor);
-
-        // Get a scaled copy of the vector
-        [[nodiscard]] ML_FUNC_DECL Vector2 GetScaled(const float& factor) const;
-
-        // Normalize in place
-        ML_FUNC_DECL Vector2& Normalize();
-
-        // Get a normalized copy of the vector
-        [[nodiscard]] ML_FUNC_DECL Vector2 GetNormalized() const;
-
-        // Normalize in place.
-        // Check for length != 0
-        ML_FUNC_DECL Vector2& SafeNormalize();
-
-        // Get a normalized copy of the vector
-        // If vector length == 0, return Vector{0}
-        [[nodiscard]] ML_FUNC_DECL Vector2 GetSafeNormalized() const;
-
-        [[nodiscard]] ML_FUNC_DECL bool Equals(const Vector2& rhs) const;
-        [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
-
-        ML_FUNC_DECL Vector2& operator=(const Vector2& other);
-
-        [[nodiscard]] ML_FUNC_DECL bool operator==(const Vector2& rhs) const;
-
-        [[nodiscard]] ML_FUNC_DECL bool operator!=(const Vector2& rhs) const;
-
-        [[nodiscard]] ML_FUNC_DECL const T& operator[](int idx) const;
-        [[nodiscard]] ML_FUNC_DECL T& operator[](int idx);
-
-        ML_FUNC_DECL Vector2& Add(const Vector2& vec);
-        [[nodiscard]] ML_FUNC_DECL Vector2 operator+(const Vector2& rhs) const;
-        ML_FUNC_DECL Vector2& operator+=(const Vector2& vec);
-        ML_FUNC_DECL Vector2& operator++();
-
-        ML_FUNC_DECL Vector2& Sub(const Vector2& vec);
-        [[nodiscard]] ML_FUNC_DECL Vector2 operator-(const Vector2& rhs) const;
-        ML_FUNC_DECL Vector2& operator-=(const Vector2& vec);
-        ML_FUNC_DECL Vector2& operator--();
-
-        [[nodiscard]] ML_FUNC_DECL Vector2 operator*(const float& scalar) const;
-        ML_FUNC_DECL Vector2& operator*=(const float& scalar);
-
-        [[nodiscard]] ML_FUNC_DECL Vector2 operator/(const float& scalar) const;
-        ML_FUNC_DECL Vector2& operator/=(const float& scalar);
-
-
-    };
-
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector2<T> operator-(Vector2<T> vec);
-
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector2<T> operator*(const float& scalar, Vector2<T> rhs);
-
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector2<T> Lerp(Vector2<T> begin, Vector2<T> end, float ratio);
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector2<T> Lerp(BwatEngine::Math::Internal::Vector2<T> begin,
+                                                                       BwatEngine::Math::Internal::Vector2<T> end,
+                                                                       float ratio);
 
 #pragma endregion
 
 #pragma region Definitions
-
+namespace BwatEngine::Math
+{
     template<typename T>
-    ML_FUNC_DECL float Vector2<T>::DotProduct(const Vector2& v) const
+    ML_FUNC_DECL float Internal::Vector2<T>::DotProduct(const Internal::Vector2<T> &v) const
     {
         return (X * v.X + Y * v.Y);
     }
 
     template<typename T>
-    ML_FUNC_DECL float Vector2<T>::Amplitude() const
+    ML_FUNC_DECL float Internal::Vector2<T>::Amplitude() const
     {
         return DotProduct(*this);
     }
 
     template<typename T>
-    ML_FUNC_DECL float Vector2<T>::Length() const
+    ML_FUNC_DECL float Internal::Vector2<T>::Length() const
     {
         return std::sqrt(Amplitude());
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::Add(const Vector2& vec)
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::Add(const Internal::Vector2<T> &vec)
     {
         *this += vec;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::Sub(const Vector2& vec)
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::Sub(const Internal::Vector2<T> &vec)
     {
         *this -= vec;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::Scale(const float& factor)
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::Scale(const float &factor)
     {
         *this *= factor;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T> Vector2<T>::GetScaled(const float& factor) const
+    ML_FUNC_DECL Internal::Vector2<T> Internal::Vector2<T>::GetScaled(const float &factor) const
     {
         return *this * factor;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::Normalize()
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::Normalize()
     {
         *this /= Length();
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T> Vector2<T>::GetNormalized() const
+    ML_FUNC_DECL Internal::Vector2<T> Internal::Vector2<T>::GetNormalized() const
     {
-        return Vector2{*this} / Length();
+        return Internal::Vector2{*this} / Length();
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::SafeNormalize()
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::SafeNormalize()
     {
         if (Amplitude() == 0) return *this;
         return Normalize();
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T> Vector2<T>::GetSafeNormalized() const
+    ML_FUNC_DECL Internal::Vector2<T> Internal::Vector2<T>::GetSafeNormalized() const
     {
-        if (Amplitude() == 0) return Vector2<T>{0};
+        if (Amplitude() == 0) return Internal::Vector2<T>{0};
         return GetNormalized();
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector2<T>::Equals(const Vector2& rhs) const
+    ML_FUNC_DECL bool Internal::Vector2<T>::Equals(const Internal::Vector2<T> &rhs) const
     {
         return *this == rhs;
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector2<T>::IsZero() const
+    ML_FUNC_DECL bool Internal::Vector2<T>::IsZero() const
     {
-        return *this == Vector2<T>{0};
+        return *this == Internal::Vector2<T>{0};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::operator=(const Vector2& other)
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::operator=(const Internal::Vector2<T> &other)
     {
         X = other.X;
         Y = other.Y;
@@ -211,39 +224,39 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector2<T>::operator==(const Vector2& rhs) const
+    ML_FUNC_DECL bool Internal::Vector2<T>::operator==(const Internal::Vector2<T> &rhs) const
     {
         return (X == rhs.X &&
-                Y == rhs.Y);
+            Y == rhs.Y);
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector2<T>::operator!=(const Vector2& rhs) const
+    ML_FUNC_DECL bool Internal::Vector2<T>::operator!=(const Internal::Vector2<T> &rhs) const
     {
         return !(*this == rhs);
     }
 
     template<typename T>
-    ML_FUNC_DECL const T& Vector2<T>::operator[](int idx) const
+    ML_FUNC_DECL const T &Internal::Vector2<T>::operator[](int idx) const
     {
         return values[idx];
     }
 
     template<typename T>
-    ML_FUNC_DECL T& Vector2<T>::operator[](int idx)
+    ML_FUNC_DECL T &Internal::Vector2<T>::operator[](int idx)
     {
         return values[idx];
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T> Vector2<T>::operator+(const Vector2& rhs) const
+    ML_FUNC_DECL Internal::Vector2<T> Internal::Vector2<T>::operator+(const Internal::Vector2<T> &rhs) const
     {
-        return Vector2<T>{X + rhs.X,
-                          Y + rhs.Y};
+        return Internal::Vector2<T>{X + rhs.X,
+                                    Y + rhs.Y};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::operator+=(const Vector2& vec)
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::operator+=(const Internal::Vector2<T> &vec)
     {
         X += vec.X;
         Y += vec.Y;
@@ -251,7 +264,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::operator++()
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::operator++()
     {
         X++;
         Y++;
@@ -259,14 +272,14 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T> Vector2<T>::operator-(const Vector2& rhs) const
+    ML_FUNC_DECL Internal::Vector2<T> Internal::Vector2<T>::operator-(const Internal::Vector2<T> &rhs) const
     {
-        return Vector2<T>{X - rhs.X,
-                          Y - rhs.Y};
+        return Internal::Vector2<T>{X - rhs.X,
+                                    Y - rhs.Y};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::operator-=(const Vector2& vec)
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::operator-=(const Internal::Vector2<T> &vec)
     {
         X -= vec.X;
         Y -= vec.Y;
@@ -274,34 +287,24 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::operator--()
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::operator--()
     {
         X--;
         Y--;
         return *this;
     }
 
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector2<T> operator-(Vector2<T> vec)
-    {
-        return Vector2<T>{-vec.X, -vec.Y};
-    }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T> Vector2<T>::operator*(const float& scalar) const
+    ML_FUNC_DECL Internal::Vector2<T> Internal::Vector2<T>::operator*(const float &scalar) const
     {
-        return Vector2<T>{X * scalar,
-                          Y * scalar};
+        return Internal::Vector2<T>{X * scalar,
+                                    Y * scalar};
     }
 
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector2<T> operator*(const float& scalar, Vector2<T> rhs)
-    {
-        return rhs * scalar;
-    }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::operator*=(const float& scalar)
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::operator*=(const float &scalar)
     {
         X *= scalar;
         Y *= scalar;
@@ -309,27 +312,40 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T> Vector2<T>::operator/(const float& scalar) const
+    ML_FUNC_DECL Internal::Vector2<T> Internal::Vector2<T>::operator/(const float &scalar) const
     {
-        return Vector2<T>{X / scalar,
-                          Y / scalar};
+        return Internal::Vector2<T>{X / scalar,
+                                    Y / scalar};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector2<T>& Vector2<T>::operator/=(const float& scalar)
+    ML_FUNC_DECL Internal::Vector2<T> &Internal::Vector2<T>::operator/=(const float &scalar)
     {
         X /= scalar;
         Y /= scalar;
         return *this;
     }
+}
 
-    template<typename T>
-    ML_FUNC_DECL Vector2<T> Lerp(Vector2<T> begin, Vector2<T> end, float ratio) {
-        ratio = (ratio > 1) ? 1 : (ratio < 0) ?  0 : ratio;
-        return (1 - ratio) * begin + ratio * end;
-    }
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector2<T> operator-(BwatEngine::Math::Internal::Vector2<T> vec)
+{
+    return BwatEngine::Math::Internal::Vector2<T>{-vec.X, -vec.Y};
+}
 
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector2<T> operator*(const float &scalar, BwatEngine::Math::Internal::Vector2<T> rhs)
+{
+    return rhs * scalar;
+}
+
+template<typename T>
+ML_FUNC_DECL BwatEngine::Math::Internal::Vector2<T> Lerp(BwatEngine::Math::Internal::Vector2<T> begin, BwatEngine::Math::Internal::Vector2<T> end, float ratio)
+{
+    ratio = (ratio > 1) ? 1 : (ratio < 0) ? 0 : ratio;
+    return (1 - ratio) * begin + ratio * end;
+}
 #pragma endregion
 
-}
+
 #endif //MATH_VECTOR2_HPP

--- a/Engine/include/Math/Vector/Vector3.hpp
+++ b/Engine/include/Math/Vector/Vector3.hpp
@@ -7,206 +7,229 @@
 
 #include "Math/Meta.hpp"
 
-namespace BMath
+namespace BwatEngine::Math
 {
 
 #pragma region Declarations
 
-    template<typename T>
-    class Vector3
+    namespace Internal
     {
-    public:
-        union
+        template<typename T>
+        class Vector3
         {
-            struct
+        public:
+            union
             {
-                T X;
-                T Y;
-                T Z;
+                struct
+                {
+                    T X;
+                    T Y;
+                    T Z;
+                };
+                T values[3];
             };
-            T values[3];
+
+            ML_FUNC_DECL Vector3(T x = 0)
+                : X(x), Y(x), Z(x)
+            {}
+
+            ML_FUNC_DECL Vector3(T x, T y, T z)
+                : X(x), Y(y), Z(z)
+            {}
+
+            ML_FUNC_DECL Vector3(const Vector3 &vec) = default;
+            ML_FUNC_DECL Vector3(Vector3 &&vec) noexcept = default;
+
+            template<typename U>
+            ML_FUNC_DECL Vector3(const Vector3<U> &vec)
+                : X(static_cast<T>(vec.X)), Y(static_cast<T>(vec.Y)), Z(static_cast<T>(vec.Z))
+            {}
+
+            ~Vector3() = default;
+
+            [[nodiscard]] ML_FUNC_DECL float DotProduct(const Vector3 &v) const;
+
+            [[nodiscard]] ML_FUNC_DECL Vector3 CrossProduct(const Vector3 &other) const;
+
+            // Compute the amplitude without computing the sqrt
+            // Valid for comparisons, but actually equals to length squared
+            [[nodiscard]] ML_FUNC_DECL float Amplitude() const;
+
+            // Return the length of the vector
+            // If you only need it for comparison consider using Amplitude()
+            [[nodiscard]] ML_FUNC_DECL float Length() const;
+
+            // Scale in place
+            ML_FUNC_DECL Vector3 &Scale(const float &factor);
+
+            // Get a scaled copy of the vector
+            [[nodiscard]] ML_FUNC_DECL Vector3 GetScaled(const float &factor) const;
+
+            // Normalize in place
+            ML_FUNC_DECL Vector3 &Normalize();
+
+            // Get a normalized copy of the vector
+            [[nodiscard]] ML_FUNC_DECL Vector3 GetNormalized() const;
+
+            // Normalize in place.
+            // Check for length != 0
+            ML_FUNC_DECL Vector3 &SafeNormalize();
+
+            // Get a normalized copy of the vector
+            // If vector length == 0, return Vector{0}
+            [[nodiscard]] ML_FUNC_DECL Vector3 GetSafeNormalized() const;
+
+            [[nodiscard]] ML_FUNC_DECL bool Equals(const Vector3 &rhs) const;
+            [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
+
+            ML_FUNC_DECL Vector3 &operator=(const Vector3 &other);
+
+            [[nodiscard]] ML_FUNC_DECL bool operator==(const Vector3 &rhs) const;
+
+            [[nodiscard]] ML_FUNC_DECL bool operator!=(const Vector3 &rhs) const;
+
+            [[nodiscard]] ML_FUNC_DECL const T &operator[](int idx) const;
+            [[nodiscard]] ML_FUNC_DECL T &operator[](int idx);
+
+            ML_FUNC_DECL Vector3 &Add(const Vector3 &vec);
+            [[nodiscard]] ML_FUNC_DECL Vector3 operator+(const Vector3 &rhs) const;
+            ML_FUNC_DECL Vector3 &operator+=(const Vector3 &vec);
+            ML_FUNC_DECL Vector3 &operator++();
+
+            ML_FUNC_DECL Vector3 &Sub(const Vector3 &vec);
+            [[nodiscard]] ML_FUNC_DECL Vector3 operator-(const Vector3 &rhs) const;
+            ML_FUNC_DECL Vector3 &operator-=(const Vector3 &vec);
+            ML_FUNC_DECL Vector3 &operator--();
+
+            [[nodiscard]] ML_FUNC_DECL Vector3 operator*(const float &scalar) const;
+            ML_FUNC_DECL Vector3 &operator*=(const float &scalar);
+
+            [[nodiscard]] ML_FUNC_DECL Vector3 operator/(const float &scalar) const;
+            ML_FUNC_DECL Vector3 &operator/=(const float &scalar);
+
         };
+    }
 
-        ML_FUNC_DECL Vector3(T x = 0)
-            : X(x), Y(x), Z(x)
-        {}
+    typedef Internal::Vector3<float> Vec3f;
 
-        ML_FUNC_DECL Vector3(T x, T y, T z)
-            : X(x), Y(y), Z(z)
-        {}
+    typedef Internal::Vector3<double> Vec3d;
 
-        ML_FUNC_DECL Vector3(const Vector3& vec) = default;
-        ML_FUNC_DECL Vector3(Vector3&& vec) noexcept = default;
-        ~Vector3() = default;
+    typedef Internal::Vector3<signed int> Vec3i;
 
-        [[nodiscard]] ML_FUNC_DECL float DotProduct(const Vector3& v) const;
+    typedef Internal::Vector3<unsigned int> Vec3u;
+}
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector3<T> operator-(BwatEngine::Math::Internal::Vector3<T> vec);
 
-        [[nodiscard]] ML_FUNC_DECL Vector3 CrossProduct(const Vector3& other) const;
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector3<T> operator*(const float &scalar,
+                                                                            BwatEngine::Math::Internal::Vector3<T> rhs);
 
-        // Compute the amplitude without computing the sqrt
-        // Valid for comparisons, but actually equals to length squared
-        [[nodiscard]] ML_FUNC_DECL float Amplitude() const;
-
-        // Return the length of the vector
-        // If you only need it for comparison consider using Amplitude()
-        [[nodiscard]] ML_FUNC_DECL float Length() const;
-
-        // Scale in place
-        ML_FUNC_DECL Vector3& Scale(const float& factor);
-
-        // Get a scaled copy of the vector
-        [[nodiscard]] ML_FUNC_DECL Vector3 GetScaled(const float& factor) const;
-
-        // Normalize in place
-        ML_FUNC_DECL Vector3& Normalize();
-
-        // Get a normalized copy of the vector
-        [[nodiscard]] ML_FUNC_DECL Vector3 GetNormalized() const;
-
-        // Normalize in place.
-        // Check for length != 0
-        ML_FUNC_DECL Vector3& SafeNormalize();
-
-        // Get a normalized copy of the vector
-        // If vector length == 0, return Vector{0}
-        [[nodiscard]] ML_FUNC_DECL Vector3 GetSafeNormalized() const;
-
-        [[nodiscard]] ML_FUNC_DECL bool Equals(const Vector3& rhs) const;
-        [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
-
-        ML_FUNC_DECL Vector3& operator=(const Vector3& other);
-
-        [[nodiscard]] ML_FUNC_DECL bool operator==(const Vector3& rhs) const;
-
-        [[nodiscard]] ML_FUNC_DECL bool operator!=(const Vector3& rhs) const;
-
-        [[nodiscard]] ML_FUNC_DECL const T& operator[](int idx) const;
-        [[nodiscard]] ML_FUNC_DECL T& operator[](int idx);
-
-        ML_FUNC_DECL Vector3& Add(const Vector3& vec);
-        [[nodiscard]] ML_FUNC_DECL Vector3 operator+(const Vector3& rhs) const;
-        ML_FUNC_DECL Vector3& operator+=(const Vector3& vec);
-        ML_FUNC_DECL Vector3& operator++();
-
-        ML_FUNC_DECL Vector3& Sub(const Vector3& vec);
-        [[nodiscard]] ML_FUNC_DECL Vector3 operator-(const Vector3& rhs) const;
-        ML_FUNC_DECL Vector3& operator-=(const Vector3& vec);
-        ML_FUNC_DECL Vector3& operator--();
-
-        [[nodiscard]] ML_FUNC_DECL Vector3 operator*(const float& scalar) const;
-        ML_FUNC_DECL Vector3& operator*=(const float& scalar);
-
-        [[nodiscard]] ML_FUNC_DECL Vector3 operator/(const float& scalar) const;
-        ML_FUNC_DECL Vector3& operator/=(const float& scalar);
-
-    };
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector3<T> operator-(Vector3<T> vec);
-
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector3<T> operator*(const float& scalar, Vector3<T> rhs);
-
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector3<T> Lerp(Vector3<T> begin, Vector3<T> end, float ratio);
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector3<T> Lerp(BwatEngine::Math::Internal::Vector3<T> begin,
+                                                                       BwatEngine::Math::Internal::Vector3<T> end,
+                                                                       float ratio);
 
 #pragma endregion
 
 #pragma region Definitions
+namespace BwatEngine::Math
+{
 
     template<typename T>
-    ML_FUNC_DECL float Vector3<T>::DotProduct(const Vector3& v) const
+    ML_FUNC_DECL float Internal::Vector3<T>::DotProduct(const Internal::Vector3<T> &v) const
     {
         return (X * v.X + Y * v.Y + Z * v.Z);
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T> Vector3<T>::CrossProduct(const Vector3<T>& other) const
+    ML_FUNC_DECL Internal::Vector3<T> Internal::Vector3<T>::CrossProduct(const Internal::Vector3<T> &other) const
     {
-        return Vector3<T>{Y * other.Z - other.Y * Z,
-                          Z * other.X - other.Z * X,
-                          X * other.Y - other.X * Y};
+        return Internal::Vector3<T>{Y * other.Z - other.Y * Z,
+                                    Z * other.X - other.Z * X,
+                                    X * other.Y - other.X * Y};
     }
 
     template<typename T>
-    ML_FUNC_DECL float Vector3<T>::Amplitude() const
+    ML_FUNC_DECL float Internal::Vector3<T>::Amplitude() const
     {
         return DotProduct(*this);
     }
 
     template<typename T>
-    ML_FUNC_DECL float Vector3<T>::Length() const
+    ML_FUNC_DECL float Internal::Vector3<T>::Length() const
     {
         return std::sqrt(Amplitude());
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::Add(const Vector3& vec)
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::Add(const Internal::Vector3<T> &vec)
     {
         *this += vec;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::Sub(const Vector3& vec)
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::Sub(const Internal::Vector3<T> &vec)
     {
         *this -= vec;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::Scale(const float& factor)
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::Scale(const float &factor)
     {
         *this *= factor;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T> Vector3<T>::GetScaled(const float& factor) const
+    ML_FUNC_DECL Internal::Vector3<T> Internal::Vector3<T>::GetScaled(const float &factor) const
     {
         return *this * factor;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::Normalize()
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::Normalize()
     {
         *this /= Length();
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T> Vector3<T>::GetNormalized() const
+    ML_FUNC_DECL Internal::Vector3<T> Internal::Vector3<T>::GetNormalized() const
     {
-        return Vector3{*this} / Length();
+        return Internal::Vector3{*this} / Length();
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::SafeNormalize()
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::SafeNormalize()
     {
         if (Amplitude() == 0) return *this;
         return Normalize();
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T> Vector3<T>::GetSafeNormalized() const
+    ML_FUNC_DECL Internal::Vector3<T> Internal::Vector3<T>::GetSafeNormalized() const
     {
-        if (Amplitude() == 0) return Vector3<T>{0};
+        if (Amplitude() == 0) return Internal::Vector3<T>{0};
         return GetNormalized();
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector3<T>::Equals(const Vector3& rhs) const
+    ML_FUNC_DECL bool Internal::Vector3<T>::Equals(const Internal::Vector3<T> &rhs) const
     {
         return *this == rhs;
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector3<T>::IsZero() const
+    ML_FUNC_DECL bool Internal::Vector3<T>::IsZero() const
     {
-        return *this == Vector3<T>{0};
+        return *this == Internal::Vector3<T>{0};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::operator=(const Vector3& other)
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::operator=(const Internal::Vector3<T> &other)
     {
         X = other.X;
         Y = other.Y;
@@ -215,41 +238,41 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector3<T>::operator==(const Vector3& rhs) const
+    ML_FUNC_DECL bool Internal::Vector3<T>::operator==(const Internal::Vector3<T> &rhs) const
     {
         return (X == rhs.X &&
-                Y == rhs.Y &&
-                Z == rhs.Z);
+            Y == rhs.Y &&
+            Z == rhs.Z);
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector3<T>::operator!=(const Vector3& rhs) const
+    ML_FUNC_DECL bool Internal::Vector3<T>::operator!=(const Internal::Vector3<T> &rhs) const
     {
         return !(*this == rhs);
     }
 
     template<typename T>
-    ML_FUNC_DECL const T& Vector3<T>::operator[](int idx) const
+    ML_FUNC_DECL const T &Internal::Vector3<T>::operator[](int idx) const
     {
         return values[idx];
     }
 
     template<typename T>
-    ML_FUNC_DECL T& Vector3<T>::operator[](int idx)
+    ML_FUNC_DECL T &Internal::Vector3<T>::operator[](int idx)
     {
         return values[idx];
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T> Vector3<T>::operator+(const Vector3& rhs) const
+    ML_FUNC_DECL Internal::Vector3<T> Internal::Vector3<T>::operator+(const Internal::Vector3<T> &rhs) const
     {
-        return Vector3<T>{X + rhs.X,
-                          Y + rhs.Y,
-                          Z + rhs.Z};
+        return Internal::Vector3<T>{X + rhs.X,
+                                    Y + rhs.Y,
+                                    Z + rhs.Z};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::operator+=(const Vector3& vec)
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::operator+=(const Internal::Vector3<T> &vec)
     {
         X += vec.X;
         Y += vec.Y;
@@ -258,7 +281,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::operator++()
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::operator++()
     {
         X++;
         Y++;
@@ -267,15 +290,15 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T> Vector3<T>::operator-(const Vector3& rhs) const
+    ML_FUNC_DECL Internal::Vector3<T> Internal::Vector3<T>::operator-(const Internal::Vector3<T> &rhs) const
     {
-        return Vector3<T>{X - rhs.X,
-                          Y - rhs.Y,
-                          Z - rhs.Z};
+        return Internal::Vector3<T>{X - rhs.X,
+                                    Y - rhs.Y,
+                                    Z - rhs.Z};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::operator-=(const Vector3& vec)
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::operator-=(const Internal::Vector3<T> &vec)
     {
         X -= vec.X;
         Y -= vec.Y;
@@ -284,7 +307,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::operator--()
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::operator--()
     {
         X--;
         Y--;
@@ -292,28 +315,18 @@ namespace BMath
         return *this;
     }
 
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector3<T> operator-(Vector3<T> vec)
-    {
-        return Vector3<T>{-vec.X, -vec.Y, -vec.Z};
-    }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T> Vector3<T>::operator*(const float& scalar) const
+    ML_FUNC_DECL Internal::Vector3<T> Internal::Vector3<T>::operator*(const float &scalar) const
     {
-        return Vector3<T>{X * scalar,
-                          Y * scalar,
-                          Z * scalar};
+        return Internal::Vector3<T>{X * scalar,
+                                    Y * scalar,
+                                    Z * scalar};
     }
 
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector3<T> operator*(const float& scalar, Vector3<T> rhs)
-    {
-        return rhs * scalar;
-    }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::operator*=(const float& scalar)
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::operator*=(const float &scalar)
     {
         X *= scalar;
         Y *= scalar;
@@ -322,15 +335,15 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T> Vector3<T>::operator/(const float& scalar) const
+    ML_FUNC_DECL Internal::Vector3<T> Internal::Vector3<T>::operator/(const float &scalar) const
     {
-        return Vector3<T>{X / scalar,
-                          Y / scalar,
-                          Z / scalar};
+        return Internal::Vector3<T>{X / scalar,
+                                    Y / scalar,
+                                    Z / scalar};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector3<T>& Vector3<T>::operator/=(const float& scalar)
+    ML_FUNC_DECL Internal::Vector3<T> &Internal::Vector3<T>::operator/=(const float &scalar)
     {
         X /= scalar;
         Y /= scalar;
@@ -338,13 +351,28 @@ namespace BMath
         return *this;
     }
 
-    template<typename T>
-    ML_FUNC_DECL Vector3<T> Lerp(Vector3<T> begin, Vector3<T> end, float ratio) {
-        ratio = (ratio > 1) ? 1 : (ratio < 0) ?  0 : ratio;
-        return (1 - ratio) * begin + ratio * end;
-    }
-
-#pragma endregion;
 
 }
+
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector3<T> operator-(BwatEngine::Math::Internal::Vector3<T> vec)
+{
+    return BwatEngine::Math::Internal::Vector3<T>{-vec.X, -vec.Y, -vec.Z};
+}
+
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector3<T> operator*(const float &scalar, BwatEngine::Math::Internal::Vector3<T> rhs)
+{
+    return rhs * scalar;
+}
+
+template<typename T>
+ML_FUNC_DECL BwatEngine::Math::Internal::Vector3<T> Lerp(BwatEngine::Math::Internal::Vector3<T> begin, BwatEngine::Math::Internal::Vector3<T> end, float ratio)
+{
+    ratio = (ratio > 1) ? 1 : (ratio < 0) ? 0 : ratio;
+    return (1 - ratio) * begin + ratio * end;
+}
+#pragma endregion;
+
+
 #endif //MATH_VECTOR3_HPP

--- a/Engine/include/Math/Vector/Vector4.hpp
+++ b/Engine/include/Math/Vector/Vector4.hpp
@@ -7,197 +7,214 @@
 
 #include "Math/Meta.hpp"
 
-namespace BMath
+namespace BwatEngine::Math
 {
 
 #pragma region Declarations
-
-    template<typename T>
-    class Vector4
+    namespace Internal
     {
-    public:
-        union
+        template<typename T>
+        class Vector4
         {
-            struct
+        public:
+            union
             {
-                T X;
-                T Y;
-                T Z;
-                T W;
+                struct
+                {
+                    T X;
+                    T Y;
+                    T Z;
+                    T W;
+                };
+                T values[4];
             };
-            T values[4];
-        };
 
-        ML_FUNC_DECL Vector4(T x = 0)
+            ML_FUNC_DECL Vector4(T x = 0)
                 : X(x), Y(x), Z(x), W(x)
-        {}
+            {}
 
-        ML_FUNC_DECL Vector4(T x, T y, T z, T w)
+            ML_FUNC_DECL Vector4(T x, T y, T z, T w)
                 : X(x), Y(y), Z(z), W(w)
-        {}
+            {}
 
-        ML_FUNC_DECL Vector4(const Vector4& vec) = default;
-        ML_FUNC_DECL Vector4(Vector4&& vec) noexcept = default;
-        ~Vector4() = default;
+            ML_FUNC_DECL Vector4(const Vector4 &vec) = default;
+            ML_FUNC_DECL Vector4(Vector4 &&vec) noexcept = default;
 
-        [[nodiscard]] ML_FUNC_DECL float DotProduct(const Vector4& v) const;
+            template<typename U>
+            ML_FUNC_DECL Vector4(const Vector4<U> &vec)
+                : X(static_cast<T>(vec.X)), Y(static_cast<T>(vec.Y)), Z(static_cast<T>(vec.Z)), W(static_cast<T>(vec.W))
+            {}
 
-        // Compute the amplitude without computing the sqrt
-        // Valid for comparisons, but actually equals to length squared
-        [[nodiscard]] ML_FUNC_DECL float Amplitude() const;
+            ~Vector4() = default;
 
-        // Return the length of the vector
-        // If you only need it for comparison consider using Amplitude()
-        [[nodiscard]] ML_FUNC_DECL float Length() const;
+            [[nodiscard]] ML_FUNC_DECL float DotProduct(const Vector4 &v) const;
 
-        // Scale in place
-        ML_FUNC_DECL Vector4& Scale(const float& factor);
+            // Compute the amplitude without computing the sqrt
+            // Valid for comparisons, but actually equals to length squared
+            [[nodiscard]] ML_FUNC_DECL float Amplitude() const;
 
-        // Get a scaled copy of the vector
-        [[nodiscard]] ML_FUNC_DECL Vector4 GetScaled(const float& factor) const;
+            // Return the length of the vector
+            // If you only need it for comparison consider using Amplitude()
+            [[nodiscard]] ML_FUNC_DECL float Length() const;
 
-        // Normalize in place
-        ML_FUNC_DECL Vector4& Normalize();
+            // Scale in place
+            ML_FUNC_DECL Vector4 &Scale(const float &factor);
 
-        // Get a normalized copy of the vector
-        [[nodiscard]] ML_FUNC_DECL Vector4 GetNormalized() const;
+            // Get a scaled copy of the vector
+            [[nodiscard]] ML_FUNC_DECL Vector4 GetScaled(const float &factor) const;
 
-        // Normalize in place.
-        // Check for length != 0
-        ML_FUNC_DECL Vector4& SafeNormalize();
+            // Normalize in place
+            ML_FUNC_DECL Vector4 &Normalize();
 
-        // Get a normalized copy of the vector
-        // If vector length == 0, return Vector{0}
-        [[nodiscard]] ML_FUNC_DECL Vector4 GetSafeNormalized() const;
+            // Get a normalized copy of the vector
+            [[nodiscard]] ML_FUNC_DECL Vector4 GetNormalized() const;
 
-        [[nodiscard]] ML_FUNC_DECL bool Equals(const Vector4& rhs) const;
-        [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
+            // Normalize in place.
+            // Check for length != 0
+            ML_FUNC_DECL Vector4 &SafeNormalize();
 
-        ML_FUNC_DECL Vector4& operator=(const Vector4& other);
+            // Get a normalized copy of the vector
+            // If vector length == 0, return Vector{0}
+            [[nodiscard]] ML_FUNC_DECL Vector4 GetSafeNormalized() const;
 
-        [[nodiscard]] ML_FUNC_DECL bool operator==(const Vector4& rhs) const;
+            [[nodiscard]] ML_FUNC_DECL bool Equals(const Vector4 &rhs) const;
+            [[nodiscard]] ML_FUNC_DECL bool IsZero() const;
 
-        [[nodiscard]] ML_FUNC_DECL bool operator!=(const Vector4& rhs) const;
+            ML_FUNC_DECL Vector4 &operator=(const Vector4 &other);
 
-        [[nodiscard]] ML_FUNC_DECL const T& operator[](int idx) const;
-        [[nodiscard]] ML_FUNC_DECL T& operator[](int idx);
+            [[nodiscard]] ML_FUNC_DECL bool operator==(const Vector4 &rhs) const;
 
-        ML_FUNC_DECL Vector4& Add(const Vector4& vec);
-        [[nodiscard]] ML_FUNC_DECL Vector4 operator+(const Vector4& rhs) const;
-        ML_FUNC_DECL Vector4& operator+=(const Vector4& vec);
-        ML_FUNC_DECL Vector4& operator++();
+            [[nodiscard]] ML_FUNC_DECL bool operator!=(const Vector4 &rhs) const;
 
-        ML_FUNC_DECL Vector4& Sub(const Vector4& vec);
-        [[nodiscard]] ML_FUNC_DECL Vector4 operator-(const Vector4& rhs) const;
-        ML_FUNC_DECL Vector4& operator-=(const Vector4& vec);
-        ML_FUNC_DECL Vector4& operator--();
+            [[nodiscard]] ML_FUNC_DECL const T &operator[](int idx) const;
+            [[nodiscard]] ML_FUNC_DECL T &operator[](int idx);
 
-        [[nodiscard]] ML_FUNC_DECL Vector4 operator*(const float& scalar) const;
-        ML_FUNC_DECL Vector4& operator*=(const float& scalar);
+            ML_FUNC_DECL Vector4 &Add(const Vector4 &vec);
+            [[nodiscard]] ML_FUNC_DECL Vector4 operator+(const Vector4 &rhs) const;
+            ML_FUNC_DECL Vector4 &operator+=(const Vector4 &vec);
+            ML_FUNC_DECL Vector4 &operator++();
 
-        [[nodiscard]] ML_FUNC_DECL Vector4 operator/(const float& scalar) const;
-        ML_FUNC_DECL Vector4& operator/=(const float& scalar);
+            ML_FUNC_DECL Vector4 &Sub(const Vector4 &vec);
+            [[nodiscard]] ML_FUNC_DECL Vector4 operator-(const Vector4 &rhs) const;
+            ML_FUNC_DECL Vector4 &operator-=(const Vector4 &vec);
+            ML_FUNC_DECL Vector4 &operator--();
 
-    };
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector4<T> operator-(Vector4<T> vec);
+            [[nodiscard]] ML_FUNC_DECL Vector4 operator*(const float &scalar) const;
+            ML_FUNC_DECL Vector4 &operator*=(const float &scalar);
 
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector4<T> operator*(const float& scalar, Vector4<T> rhs);
+            [[nodiscard]] ML_FUNC_DECL Vector4 operator/(const float &scalar) const;
+            ML_FUNC_DECL Vector4 &operator/=(const float &scalar);
 
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector4<T> Lerp(Vector4<T> begin, Vector4<T> end, float ratio);
+        };
+    }
+    typedef BwatEngine::Math::Internal::Vector4<float> Vec4f;
+    typedef BwatEngine::Math::Internal::Vector4<double> Vec4d;
+    typedef BwatEngine::Math::Internal::Vector4<signed int> Vec4i;
+    typedef BwatEngine::Math::Internal::Vector4<unsigned int> Vec4u;
+}
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector4<T> operator-(BwatEngine::Math::Internal::Vector4<T> vec);
+
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector4<T> operator*(const float& scalar,
+                                                                            BwatEngine::Math::Internal::Vector4<T> rhs);
+
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector4<T> Lerp(BwatEngine::Math::Internal::Vector4<T> begin,
+                                                                       BwatEngine::Math::Internal::Vector4<T> end,
+                                                                       float ratio);
 
 #pragma endregion
 
 #pragma region Definitions
-
+namespace BwatEngine::Math
+{
     template<typename T>
-    ML_FUNC_DECL float Vector4<T>::DotProduct(const Vector4& v) const
+    ML_FUNC_DECL float Internal::Vector4<T>::DotProduct(const Internal::Vector4<T> &v) const
     {
         return (X * v.X + Y * v.Y + Z * v.Z + W * v.W);
     }
 
     template<typename T>
-    ML_FUNC_DECL float Vector4<T>::Amplitude() const
+    ML_FUNC_DECL float Internal::Vector4<T>::Amplitude() const
     {
         return DotProduct(*this);
     }
 
     template<typename T>
-    ML_FUNC_DECL float Vector4<T>::Length() const
+    ML_FUNC_DECL float Internal::Vector4<T>::Length() const
     {
         return std::sqrt(Amplitude());
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::Add(const Vector4& vec)
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::Add(const Internal::Vector4<T> &vec)
     {
         *this += vec;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::Sub(const Vector4& vec)
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::Sub(const Internal::Vector4<T> &vec)
     {
         *this -= vec;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::Scale(const float& factor)
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::Scale(const float &factor)
     {
         *this *= factor;
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T> Vector4<T>::GetScaled(const float& factor) const
+    ML_FUNC_DECL Internal::Vector4<T> Internal::Vector4<T>::GetScaled(const float &factor) const
     {
         return *this * factor;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::Normalize()
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::Normalize()
     {
         *this /= Length();
         return *this;
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T> Vector4<T>::GetNormalized() const
+    ML_FUNC_DECL Internal::Vector4<T> Internal::Vector4<T>::GetNormalized() const
     {
-        return Vector4{*this} / Length();
+        return Internal::Vector4{*this} / Length();
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::SafeNormalize()
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::SafeNormalize()
     {
         if (Amplitude() == 0) return *this;
         return Normalize();
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T> Vector4<T>::GetSafeNormalized() const
+    ML_FUNC_DECL Internal::Vector4<T> Internal::Vector4<T>::GetSafeNormalized() const
     {
-        if (Amplitude() == 0) return Vector4<T>{0};
+        if (Amplitude() == 0) return Internal::Vector4<T>{0};
         return GetNormalized();
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector4<T>::Equals(const Vector4& rhs) const
+    ML_FUNC_DECL bool Internal::Vector4<T>::Equals(const Internal::Vector4<T> &rhs) const
     {
         return *this == rhs;
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector4<T>::IsZero() const
+    ML_FUNC_DECL bool Internal::Vector4<T>::IsZero() const
     {
-        return *this == Vector4<T>{0};
+        return *this == Internal::Vector4<T>{0};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::operator=(const Vector4& other)
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::operator=(const Internal::Vector4<T> &other)
     {
         X = other.X;
         Y = other.Y;
@@ -207,43 +224,43 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector4<T>::operator==(const Vector4& rhs) const
+    ML_FUNC_DECL bool Internal::Vector4<T>::operator==(const Internal::Vector4<T> &rhs) const
     {
         return (X == rhs.X &&
-                Y == rhs.Y &&
-                Z == rhs.Z &&
-                W == rhs.W);
+            Y == rhs.Y &&
+            Z == rhs.Z &&
+            W == rhs.W);
     }
 
     template<typename T>
-    ML_FUNC_DECL bool Vector4<T>::operator!=(const Vector4& rhs) const
+    ML_FUNC_DECL bool Internal::Vector4<T>::operator!=(const Internal::Vector4<T> &rhs) const
     {
         return !(*this == rhs);
     }
 
     template<typename T>
-    ML_FUNC_DECL const T& Vector4<T>::operator[](int idx) const
+    ML_FUNC_DECL const T &Internal::Vector4<T>::operator[](int idx) const
     {
         return values[idx];
     }
 
     template<typename T>
-    ML_FUNC_DECL T& Vector4<T>::operator[](int idx)
+    ML_FUNC_DECL T &Internal::Vector4<T>::operator[](int idx)
     {
         return values[idx];
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T> Vector4<T>::operator+(const Vector4& rhs) const
+    ML_FUNC_DECL Internal::Vector4<T> Internal::Vector4<T>::operator+(const Internal::Vector4<T> &rhs) const
     {
-        return Vector4<T>{X + rhs.X,
-                          Y + rhs.Y,
-                          Z + rhs.Z,
-                          W + rhs.W};
+        return Internal::Vector4<T>{X + rhs.X,
+                                    Y + rhs.Y,
+                                    Z + rhs.Z,
+                                    W + rhs.W};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::operator+=(const Vector4& vec)
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::operator+=(const Internal::Vector4<T> &vec)
     {
         X += vec.X;
         Y += vec.Y;
@@ -253,7 +270,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::operator++()
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::operator++()
     {
         X++;
         Y++;
@@ -263,16 +280,16 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T> Vector4<T>::operator-(const Vector4& rhs) const
+    ML_FUNC_DECL Internal::Vector4<T> Internal::Vector4<T>::operator-(const Internal::Vector4<T> &rhs) const
     {
-        return Vector4<T>{X - rhs.X,
-                          Y - rhs.Y,
-                          Z - rhs.Z,
-                          W - rhs.W};
+        return Internal::Vector4<T>{X - rhs.X,
+                                    Y - rhs.Y,
+                                    Z - rhs.Z,
+                                    W - rhs.W};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::operator-=(const Vector4& vec)
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::operator-=(const Internal::Vector4<T> &vec)
     {
         X -= vec.X;
         Y -= vec.Y;
@@ -282,7 +299,7 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::operator--()
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::operator--()
     {
         X--;
         Y--;
@@ -291,29 +308,18 @@ namespace BMath
         return *this;
     }
 
+
     template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector4<T> operator-(Vector4<T> vec)
+    ML_FUNC_DECL Internal::Vector4<T> Internal::Vector4<T>::operator*(const float &scalar) const
     {
-        return Vector4<T>{-vec.X, -vec.Y, -vec.Z, -vec.W};
+        return Internal::Vector4<T>{X * scalar,
+                                    Y * scalar,
+                                    Z * scalar,
+                                    W * scalar};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T> Vector4<T>::operator*(const float& scalar) const
-    {
-        return Vector4<T>{X * scalar,
-                          Y * scalar,
-                          Z * scalar,
-                          W * scalar};
-    }
-
-    template<typename T>
-    [[nodiscard]] ML_FUNC_DECL Vector4<T> operator*(const float& scalar, Vector4<T> rhs)
-    {
-        return rhs * scalar;
-    }
-
-    template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::operator*=(const float& scalar)
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::operator*=(const float &scalar)
     {
         X *= scalar;
         Y *= scalar;
@@ -323,16 +329,16 @@ namespace BMath
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T> Vector4<T>::operator/(const float& scalar) const
+    ML_FUNC_DECL Internal::Vector4<T> Internal::Vector4<T>::operator/(const float &scalar) const
     {
-        return Vector4<T>{X / scalar,
-                          Y / scalar,
-                          Z / scalar,
-                          W / scalar};
+        return Internal::Vector4<T>{X / scalar,
+                                    Y / scalar,
+                                    Z / scalar,
+                                    W / scalar};
     }
 
     template<typename T>
-    ML_FUNC_DECL Vector4<T>& Vector4<T>::operator/=(const float& scalar)
+    ML_FUNC_DECL Internal::Vector4<T> &Internal::Vector4<T>::operator/=(const float &scalar)
     {
         X /= scalar;
         Y /= scalar;
@@ -340,14 +346,28 @@ namespace BMath
         W /= scalar;
         return *this;
     }
+}
 
-    template<typename T>
-    ML_FUNC_DECL Vector4<T> Lerp(Vector4<T> begin, Vector4<T> end, float ratio) {
-        ratio = (ratio > 1) ? 1 : (ratio < 0) ?  0 : ratio;
-        return (1 - ratio) * begin + ratio * end;
-    }
 
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector4<T> operator-(BwatEngine::Math::Internal::Vector4<T> vec)
+{
+    return BwatEngine::Math::Internal::Vector4<T>{-vec.X, -vec.Y, -vec.Z, -vec.W};
+}
+
+template<typename T>
+[[nodiscard]] ML_FUNC_DECL BwatEngine::Math::Internal::Vector4<T> operator*(const float &scalar, BwatEngine::Math::Internal::Vector4<T> rhs)
+{
+    return rhs * scalar;
+}
+
+template<typename T>
+ML_FUNC_DECL BwatEngine::Math::Internal::Vector4<T> Lerp(BwatEngine::Math::Internal::Vector4<T> begin, BwatEngine::Math::Internal::Vector4<T> end, float ratio)
+{
+    ratio = (ratio > 1) ? 1 : (ratio < 0) ? 0 : ratio;
+    return (1 - ratio) * begin + ratio * end;
+}
 #pragma endregion
 
-}
+
 #endif //MATH_VECTOR4_HPP

--- a/Engine/include/Math/Vector/Vectors.hpp
+++ b/Engine/include/Math/Vector/Vectors.hpp
@@ -7,22 +7,4 @@
 #include "Vector3.hpp"
 #include "Vector4.hpp"
 
-namespace BMath
-{
-    typedef Vector2<float> vec2f;
-    typedef Vector2<double> vec2d;
-    typedef Vector2<signed int> vec2i;
-    typedef Vector2<unsigned int> vec2u;
-
-    typedef Vector3<float> vec3f;
-    typedef Vector3<double> vec3d;
-    typedef Vector3<signed int> vec3i;
-    typedef Vector3<unsigned int> vec3u;
-
-    typedef Vector4<float> vec4f;
-    typedef Vector4<double> vec4d;
-    typedef Vector4<signed int> vec4i;
-    typedef Vector4<unsigned int> vec4u;
-}
-
 #endif //MATH_VECTORS_HPP


### PR DESCRIPTION
Now this is BwatEngine::Math. The templates have been hidden in the Internal
namespace and appropriate typedefs have been made